### PR TITLE
Feature/profile screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
@@ -1,6 +1,9 @@
 package com.github.se.project.ui.authentification
 
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.project.MainActivity
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -14,11 +17,11 @@ class SignInTest : TestCase() {
 
   @Test
   fun logoAndButtonAreCorrectlyDisplayed() {
-    /*composeTestRule.onNodeWithTag("logo").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("logo").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("images").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("loginButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("loginButton").assertHasClickAction()*/
+    composeTestRule.onNodeWithTag("loginButton").assertHasClickAction()
   }
 }

--- a/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
@@ -17,11 +17,11 @@ class SignInTest : TestCase() {
 
   @Test
   fun logoAndButtonAreCorrectlyDisplayed() {
-    composeTestRule.onNodeWithTag("logo").assertIsDisplayed()
+    /*composeTestRule.onNodeWithTag("logo").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("images").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("loginButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("loginButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("loginButton").assertHasClickAction()*/
   }
 }

--- a/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/authentification/SignInTest.kt
@@ -1,9 +1,6 @@
 package com.github.se.project.ui.authentification
 
-import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.project.MainActivity
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -16,8 +16,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
-import com.android.sample.model.lesson.LessonsViewModel
 import com.github.se.project.model.authentification.AuthenticationViewModel
+import com.github.se.project.model.lesson.LessonsViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.resources.C
 import com.github.se.project.ui.authentification.SignInScreen
@@ -52,7 +52,8 @@ fun PocketTutorApp() {
       viewModel(factory = ListProfilesViewModel.Factory)
   val profiles = listProfilesViewModel.profiles
 
-  val lessonViewModel: LessonsViewModel = viewModel(factory = LessonsViewModel.Factory)
+  val lessonViewModel: LessonsViewModel =
+      viewModel(factory = LessonsViewModel.Factory(listProfilesViewModel))
 
   // Google user unique id (as var to be able to pass from the SignIn to CreateProfile screens)
   var googleUid = ""

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -17,7 +17,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.github.se.project.model.authentification.AuthenticationViewModel
-import com.github.se.project.model.lesson.LessonsViewModel
+import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.resources.C
 import com.github.se.project.ui.authentification.SignInScreen
@@ -52,8 +52,7 @@ fun PocketTutorApp() {
       viewModel(factory = ListProfilesViewModel.Factory)
   val profiles = listProfilesViewModel.profiles
 
-  val lessonViewModel: LessonsViewModel =
-      viewModel(factory = LessonsViewModel.Factory(listProfilesViewModel))
+  val lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory)
 
   // Google user unique id (as var to be able to pass from the SignIn to CreateProfile screens)
   var googleUid = ""
@@ -76,7 +75,6 @@ fun PocketTutorApp() {
                     if (profile != null) {
                       // If the user already has a profile, navigate to the home screen
                       listProfilesViewModel.setCurrentProfile(profile)
-                      lessonViewModel.fetchAllLessons()
                       navigationActions.navigateTo(Screen.HOME)
                     } else {
                       // If the user doesn't have a profile, navigate to the profile creation screen

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import com.android.sample.model.lesson.LessonsViewModel
 import com.github.se.project.model.authentification.AuthenticationViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.resources.C
@@ -25,6 +26,7 @@ import com.github.se.project.ui.navigation.Route
 import com.github.se.project.ui.navigation.Screen
 import com.github.se.project.ui.profile.AvailabilityScreen
 import com.github.se.project.ui.profile.CreateProfileScreen
+import com.github.se.project.ui.profile.ProfileInfoScreen
 import com.github.se.project.ui.profile.TutorInfoScreen
 import com.github.se.project.ui.theme.SampleAppTheme
 
@@ -49,6 +51,8 @@ fun PocketTutorApp() {
   val listProfilesViewModel: ListProfilesViewModel =
       viewModel(factory = ListProfilesViewModel.Factory)
   val profiles = listProfilesViewModel.profiles
+
+  val lessonViewModel: LessonsViewModel = viewModel(factory = LessonsViewModel.Factory)
 
   // Google user unique id (as var to be able to pass from the SignIn to CreateProfile screens)
   var googleUid = ""
@@ -96,6 +100,9 @@ fun PocketTutorApp() {
       }
       composable(Screen.CREATE_TUTOR_SCHEDULE) {
         AvailabilityScreen(navigationActions, listProfilesViewModel)
+      }
+      composable(Screen.PROFILE) {
+        ProfileInfoScreen(navigationActions, listProfilesViewModel, lessonViewModel)
       }
     }
   }

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -76,6 +76,7 @@ fun PocketTutorApp() {
                     if (profile != null) {
                       // If the user already has a profile, navigate to the home screen
                       listProfilesViewModel.setCurrentProfile(profile)
+                      lessonViewModel.fetchAllLessons()
                       navigationActions.navigateTo(Screen.HOME)
                     } else {
                       // If the user doesn't have a profile, navigate to the profile creation screen

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -8,18 +8,7 @@ interface LessonRepository {
   fun init(onSuccess: () -> Unit)
 
   // Retrieve all lessons for a specific tutor
-  fun getLessonsByTutorUid(
-      tutorUid: String,
-      onSuccess: (List<Lesson>) -> Unit,
-      onFailure: (Exception) -> Unit
-  )
-
-  // Retrieve all lessons for a specific student
-  fun getLessonsByStudentUid(
-      studentUid: String,
-      onSuccess: (List<Lesson>) -> Unit,
-      onFailure: (Exception) -> Unit
-  )
+  fun getAllLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit)
 
   // Method to add a new lesson
   fun addLessonByUserId(

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -26,7 +26,7 @@ interface LessonRepository {
   // Method to add a new lesson
   fun addLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
-  // Method to update an existing lesson by its ID
+  // Method to update an existing lesson
   fun updateLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   // Method to delete a lesson by its ID

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -1,13 +1,22 @@
-package com.android.sample.model.lesson
+package com.github.se.project.model.lesson
+
+import com.android.sample.model.lesson.Lesson
 
 interface LessonRepository {
 
   // Method to initialize the repository
   fun init(onSuccess: () -> Unit)
 
-  // Method to retrieve all lessons by user UID
-  fun getLessonsByUserId(
-      userUid: String,
+  // Retrieve all lessons for a specific tutor
+  fun getLessonsByTutorUid(
+      tutorUid: String,
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  // Retrieve all lessons for a specific student
+  fun getLessonsByStudentUid(
+      studentUid: String,
       onSuccess: (List<Lesson>) -> Unit,
       onFailure: (Exception) -> Unit
   )

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -3,34 +3,32 @@ package com.github.se.project.model.lesson
 import com.android.sample.model.lesson.Lesson
 
 interface LessonRepository {
+  // Method to get a new unique identifier
+  fun getNewUid(): String
 
   // Method to initialize the repository
   fun init(onSuccess: () -> Unit)
 
-  // Retrieve all lessons for a specific tutor
-  fun getAllLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit)
+  // Method to retrieve all lessons for a tutor
+  fun getLessonsForTutor(
+      tutorUid: String,
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  // Method to retrieve all lessons for a student
+  fun getLessonsForStudent(
+      studentUid: String,
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
   // Method to add a new lesson
-  fun addLessonByUserId(
-      userUid: String,
-      lesson: Lesson,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  )
+  fun addLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   // Method to update an existing lesson by its ID
-  fun updateLessonByUserId(
-      userUid: String,
-      lesson: Lesson,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  )
+  fun updateLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   // Method to delete a lesson by its ID
-  fun deleteLessonByUserId(
-      userUid: String,
-      lessonId: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  )
+  fun deleteLesson(lessonId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -4,76 +4,93 @@ import android.util.Log
 import com.android.sample.model.lesson.Lesson
 import com.android.sample.model.lesson.LessonStatus
 import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 
 class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepository {
 
-  private val lessonsCollectionPath = "lessons"
+  private val collectionPath = "lessons"
+
+  // Method to get a new unique identifier
+  override fun getNewUid(): String {
+    return db.collection(collectionPath).document().id
+  }
 
   // Initialize the repository
   override fun init(onSuccess: () -> Unit) {
-    // Additional initialization logic if required
-    onSuccess()
-  }
-
-  // Fetch all lessons without filtering
-  override fun getAllLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit) {
-    db.collection(lessonsCollectionPath).get().addOnCompleteListener { task ->
-      if (task.isSuccessful) {
-        val lessons =
-            task.result?.mapNotNull { document -> documentToLesson(document) } ?: emptyList()
-        Log.d("LessonRepositoryFirestore", "All lessons: $lessons")
-        onSuccess(lessons)
-      } else {
-        task.exception?.let { e ->
-          Log.e("LessonRepositoryFirestore", "Error getting lessons", e)
-          onFailure(e)
-        }
+    FirebaseAuth.getInstance().addAuthStateListener {
+      if (it.currentUser != null) {
+        onSuccess()
       }
     }
   }
 
-  // Add a new lesson for a specific user
-  override fun addLessonByUserId(
+  // General method to retrieve lessons based on a user field (tutor or student)
+  private fun getLessonsByUserField(
+      userField: String,
       userUid: String,
-      lesson: Lesson,
-      onSuccess: () -> Unit,
+      onSuccess: (List<Lesson>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    db.collection(collectionPath)
+        .whereEqualTo(userField, userUid) // Filter lessons by user field (tutorUid or studentUid)
+        .get()
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful) {
+            val lessons =
+                task.result?.mapNotNull { document -> documentToLesson(document) } ?: emptyList()
+            onSuccess(lessons)
+          } else {
+            task.exception?.let { e ->
+              Log.e("LessonRepositoryFirestore", "Error getting lessons", e)
+              onFailure(e)
+            }
+          }
+        }
+  }
 
-    val task = db.collection(lessonsCollectionPath).document(lesson.id).set(lesson)
+  // Retrieve all lessons for a specific tutor
+  override fun getLessonsForTutor(
+      tutorUid: String,
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    getLessonsByUserField("tutorUid", tutorUid, onSuccess, onFailure)
+  }
 
+  // Retrieve all lessons for a specific student
+  override fun getLessonsForStudent(
+      studentUid: String,
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    getLessonsByUserField("studentUid", studentUid, onSuccess, onFailure)
+  }
+
+  // Add a new lesson
+  override fun addLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    val task = db.collection(collectionPath).document(lesson.id).set(lesson)
     performFirestoreOperation(task, onSuccess, onFailure)
   }
 
-  // Update an existing lesson for a specific user
-  override fun updateLessonByUserId(
-      userUid: String,
-      lesson: Lesson,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-
-    val task = db.collection(lessonsCollectionPath).document(lesson.id).set(lesson)
-
+  // Update an existing lesson by its ID
+  override fun updateLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    val task = db.collection(collectionPath).document(lesson.id).set(lesson)
     performFirestoreOperation(task, onSuccess, onFailure)
   }
 
-  // Delete a lesson by its ID for a specific user
-  override fun deleteLessonByUserId(
-      userUid: String,
+  // Delete a lesson by its ID
+  override fun deleteLesson(
       lessonId: String,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    // No need to filter by userUid because we're using the lesson ID to delete
-    val task = db.collection(lessonsCollectionPath).document(lessonId).delete()
-
+    val task = db.collection(collectionPath).document(lessonId).delete()
     performFirestoreOperation(task, onSuccess, onFailure)
   }
 
-  /*
+  /**
    * Performs a Firestore operation and calls the appropriate callback based on the result.
    *
    * @param task The Firestore task to perform.
@@ -112,9 +129,8 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
       val studentUid = document.getString("studentUid") ?: return null
       val price = document.getDouble("price") ?: return null
       val timeSlot = document.getString("timeSlot") ?: return null
-      val status = document.getString("status")?.let { LessonStatus.valueOf(it) } ?: return null
+      val status = LessonStatus.valueOf(document.getString("status") ?: return null)
       val language = document.getString("language") ?: return null
-
       Lesson(id, title, description, tutorUid, studentUid, price, timeSlot, status, language)
     } catch (e: Exception) {
       Log.e("LessonRepositoryFirestore", "Error converting document to Lesson", e)

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -34,7 +34,7 @@ class LessonsViewModel(
   private val currentUserId: String? = Firebase.auth.currentUser?.uid
 
   init {
-    fetchAllLessons()
+    repository.init { fetchAllLessons() }
   }
 
   /** Factory for creating a LessonsViewModel. */

--- a/app/src/main/java/com/github/se/project/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/profile/ProfilesRepositoryFirestore.kt
@@ -128,6 +128,7 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
       val schedule =
           document.get("schedule")?.let { (it as List<Int>).chunked(12) }
               ?: List(7) { List(12) { 0 } }
+        val price = document.getLong("price")?.toInt() ?: return null
 
       Profile(
           uid,
@@ -140,7 +141,8 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
           academicLevel,
           languages,
           subjects,
-          schedule)
+          schedule,
+          price)
     } catch (e: Exception) {
       Log.e("ProfilesRepositoryFirestore", "Error converting document to Profile", e)
       null

--- a/app/src/main/java/com/github/se/project/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/profile/ProfilesRepositoryFirestore.kt
@@ -128,7 +128,7 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
       val schedule =
           document.get("schedule")?.let { (it as List<Int>).chunked(12) }
               ?: List(7) { List(12) { 0 } }
-        val price = document.getLong("price")?.toInt() ?: return null
+      val price = document.getLong("price")?.toInt() ?: return null
 
       Profile(
           uid,

--- a/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
+++ b/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
@@ -1,0 +1,128 @@
+package com.github.se.project.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.sample.model.lesson.Lesson
+import com.android.sample.model.lesson.LessonStatus
+import com.android.sample.model.lesson.LessonsViewModel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.model.profile.Profile
+import com.github.se.project.model.profile.Role
+import com.github.se.project.ui.navigation.NavigationActions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileInfoScreen(
+    navigationActions: NavigationActions,
+    listProfilesViewModel: ListProfilesViewModel =
+        viewModel(factory = ListProfilesViewModel.Factory),
+    lessonViewModel: LessonsViewModel = viewModel(factory = LessonsViewModel.Factory)
+) {
+  val profileState = listProfilesViewModel.currentProfile.collectAsState()
+  val lessons = lessonViewModel.lessons.collectAsState()
+
+  // Filter only lessons that are marked as COMPLETED
+  val completedLessons = lessons.value.filter { it.status == LessonStatus.COMPLETED }
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text("Profile Info") },
+            navigationIcon = {
+              IconButton(onClick = { navigationActions.goBack() }) {
+                Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
+              }
+            },
+            actions = {
+              IconButton(onClick = { /* Handle edit navigation to the EDIT_TODO_SCREEN */}) {
+                Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit Profile")
+              }
+            })
+      }) { paddingValues ->
+        // must check that the profile is not null
+        profileState.value?.let { userProfile ->
+          // Pass the profile and completedLessons into ProfileDetailsScreen
+          ProfileDetailsScreen(
+              profile = userProfile,
+              completedLessons = completedLessons,
+              modifier = Modifier.padding(paddingValues))
+        }
+            ?: run {
+              // Display message if profile is null
+              Text(text = "Error loading profile...")
+            }
+      }
+}
+
+/**
+ * Displays the details of the user's profile, including their role and personal information.
+ *
+ * @param profile The current user's profile.
+ * @param completedLessons The list of completed lessons to display.
+ * @param modifier Optional modifier for the screen layout.
+ */
+@Composable
+fun ProfileDetailsScreen(
+    profile: Profile,
+    completedLessons: List<Lesson>,
+    modifier: Modifier = Modifier
+) {
+  Column(modifier = modifier.padding(16.dp)) {
+    val isTutor = profile.role == Role.TUTOR
+
+    // Display shared profile info
+    Text(text = "${profile.firstName} ${profile.lastName}")
+    Text(text = "${profile.academicLevel} ${if (isTutor) "Tutor" else "Student"}")
+    Text(text = "${profile.section}")
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Display role-specific information
+    if (isTutor) {
+      Text(text = "${profile.price} per hour", style = MaterialTheme.typography.bodyLarge)
+    }
+    DisplayLessons(completedLessons = completedLessons, isTutor = isTutor)
+  }
+}
+
+/**
+ * Displays a list of completed lessons in a lazy scrollable column.
+ *
+ * @param completedLessons The list of completed lessons to display.
+ * @param isTutor Whether the user viewing this screen is a tutor or a student.
+ */
+@Composable
+fun DisplayLessons(completedLessons: List<Lesson>, isTutor: Boolean) {
+  // display number of lessons
+  Text(text = "${completedLessons.size} ${if (isTutor) "lessons given" else "lessons taken"}")
+
+  // display the completed lessons in a LazyColumn
+  LazyColumn {
+    itemsIndexed(completedLessons) { _, lesson ->
+      if (isTutor) {
+        Text(text = "${lesson.title} with ${lesson.studentUid}")
+      } else {
+        Text(text = "${lesson.title} with ${lesson.tutorUid}")
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
+++ b/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
@@ -39,7 +39,7 @@ fun ProfileInfoScreen(
         viewModel(factory = LessonsViewModel.Factory(listProfilesViewModel))
 ) {
   val profileState = listProfilesViewModel.currentProfile.collectAsState()
-  val lessons = lessonViewModel.lessons.collectAsState()
+  val lessons = lessonViewModel.userLessons.collectAsState()
 
   // Filter only lessons that are marked as COMPLETED
   val completedLessons = lessons.value.filter { it.status == LessonStatus.COMPLETED }

--- a/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
+++ b/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.model.lesson.Lesson
 import com.android.sample.model.lesson.LessonStatus
-import com.android.sample.model.lesson.LessonsViewModel
+import com.github.se.project.model.lesson.LessonsViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.model.profile.Profile
 import com.github.se.project.model.profile.Role
@@ -35,7 +35,8 @@ fun ProfileInfoScreen(
     navigationActions: NavigationActions,
     listProfilesViewModel: ListProfilesViewModel =
         viewModel(factory = ListProfilesViewModel.Factory),
-    lessonViewModel: LessonsViewModel = viewModel(factory = LessonsViewModel.Factory)
+    lessonViewModel: LessonsViewModel =
+        viewModel(factory = LessonsViewModel.Factory(listProfilesViewModel))
 ) {
   val profileState = listProfilesViewModel.currentProfile.collectAsState()
   val lessons = lessonViewModel.lessons.collectAsState()

--- a/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
+++ b/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
@@ -98,7 +98,7 @@ fun ProfileDetailsScreen(
 
     // Display role-specific information
     if (isTutor) {
-      Text(text = "${profile.price} per hour", style = MaterialTheme.typography.bodyLarge)
+      Text(text = "${profile.price}.- per hour", style = MaterialTheme.typography.bodyLarge)
     }
     DisplayLessons(completedLessons = completedLessons, isTutor = isTutor)
   }

--- a/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
+++ b/app/src/main/java/com/github/se/project/ui/profile/ProfileInfo.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.model.lesson.Lesson
 import com.android.sample.model.lesson.LessonStatus
-import com.github.se.project.model.lesson.LessonsViewModel
+import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.model.profile.Profile
 import com.github.se.project.model.profile.Role
@@ -35,11 +35,10 @@ fun ProfileInfoScreen(
     navigationActions: NavigationActions,
     listProfilesViewModel: ListProfilesViewModel =
         viewModel(factory = ListProfilesViewModel.Factory),
-    lessonViewModel: LessonsViewModel =
-        viewModel(factory = LessonsViewModel.Factory(listProfilesViewModel))
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory)
 ) {
   val profileState = listProfilesViewModel.currentProfile.collectAsState()
-  val lessons = lessonViewModel.userLessons.collectAsState()
+  val lessons = lessonViewModel.currentUserLessons.collectAsState()
 
   // Filter only lessons that are marked as COMPLETED
   val completedLessons = lessons.value.filter { it.status == LessonStatus.COMPLETED }
@@ -61,6 +60,8 @@ fun ProfileInfoScreen(
       }) { paddingValues ->
         // must check that the profile is not null
         profileState.value?.let { userProfile ->
+          // lessonViewModel.getLessonsForTutor(userProfile.uid) uncomment if you want to fetch your
+          // lessons.
           // Pass the profile and completedLessons into ProfileDetailsScreen
           ProfileDetailsScreen(
               profile = userProfile,


### PR DESCRIPTION
# Implement Profile Infos Screen

## PR Description

This pull request introduces the `ProfileInfoScreen` along with associated changes to the navigation in `MainActivity`. It also includes a bug fix in the profiles repository of firestore (`ProfilesRepositoryFirestore.kt`). The key feature is displaying simple profile information for tutors and students, including their completed lessons, with navigation (the "go back" cross icon on top left) and edit options (the "edit" icon on top right, that will lead us to the EDIT_PROFILE_SCREEN once implemented). I chose to do a single screen used for both tutor and student instead of one screen for each because the difference between those 2 screens are quite small and can be managed quite easily.

## Summary of Changes

### Files modified:

1. **`MainActivity.kt`**  
   - Added the composable navigation for the `ProfileInfoScreen` (associated it to the Screen.PROFILE).
   - Instantiated the `LessonsViewModel` to pass it as a parameter to `ProfileInfoScreen`.
   
2. **`ProfilesRepositoryFirestore.kt`**  
   - Fixed a bug related to retrieving the `price` field from Firestore. In the original version, we just forgot the retrieve logic in the getProfiles function (which lead the price value of the profile to always be 0).
   - I decided to fix it using the getLong() method followed by a toInt() method. I also considered doing it using getString() followed by toInt(), but this seemed like a worse way to do it.

3. **`ProfileInfo.kt`**  
   - Implemented the `ProfileInfoScreen` to display the user profile and role-specific information (such as price for tutors), using a scaffold composable.
   - Integrated a `TopAppBar` with back navigation (`Close` button) and an `Edit` button for future profile edits.
   - Added `ProfileDetailsScreen`  helper to handle the display of profile data and also the completed lessons, all in a Column composable.
   - Implemented `DisplayLessons` with a LazyColumn composable to show only completed lessons, either as lessons given (for tutors) or lessons taken (for students).

## How to Test
Since this screen is supposed to appear from the lesson overview screen (by clicking on the top right profile icon), which is not implemented yet (@MPepito should push it tomorrow and create a PR), we have to do a short workaround to test it.
You can temporary replace the line 78 of `MainActivity.kt`: "navigationActions.navigateTo(Screen.HOME)" by "navigationActions.navigateTo(Screen.PROFILE)".
2 possible outcomes:
- first, you have an account linked to you google uid and thus your Profile is not null, and the info will be displayed correctly
<img width="290" alt="image" src="https://github.com/user-attachments/assets/40ad8230-917d-4385-add2-80d2c66d19c0">

- second case, you do not have an account created, thus you have to create it via the 3 Create profile screens, and then you'll be able to see it displayed :)

## Note
The screen is very simple, without fancy UI stuff. @AlexisAllmnd will make it look like the Figma asap!