### PR TITLE
test: added two test files for the lesson model

### DIFF
--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -1,6 +1,7 @@
 package com.github.se.project.model.lesson
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.android.sample.model.lesson.Lesson
 import com.android.sample.model.lesson.LessonStatus
 import com.github.se.project.model.profile.TutoringSubject
@@ -28,7 +29,7 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
   }
 
   // General method to retrieve lessons based on a user field (tutor or student)
-  private fun getLessonsByUserField(
+  internal fun getLessonsByUserField(
       userField: String,
       userUid: String,
       onSuccess: (List<Lesson>) -> Unit,
@@ -122,7 +123,8 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
    * @param document The Firestore document to convert.
    * @return The Lesson object, or null if the document could not be converted.
    */
-  private fun documentToLesson(document: DocumentSnapshot): Lesson? {
+  @VisibleForTesting
+  internal fun documentToLesson(document: DocumentSnapshot): Lesson? {
     return try {
       val id = document.id
       val title = document.getString("title") ?: return null

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
@@ -1,0 +1,134 @@
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.android.sample.model.lesson.Lesson
+import com.android.sample.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonRepositoryFirestore
+import com.github.se.project.model.profile.TutoringSubject
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class LessonRepositoryFirestoreTest {
+
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
+
+  private lateinit var lessonRepositoryFirestore: LessonRepositoryFirestore
+
+  private val lesson =
+      Lesson(
+          id = "1",
+          title = "Physics Tutoring",
+          description = "Mechanics",
+          subject = TutoringSubject.PHYSICS,
+          tutorUid = "tutor123",
+          studentUid = "student123",
+          minPrice = 20.0,
+          maxPrice = 40.0,
+          timeSlot = "2024-10-10T10:00:00",
+          status = LessonStatus.PENDING,
+          language = "ENGLISH")
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+
+    lessonRepositoryFirestore = LessonRepositoryFirestore(mockFirestore)
+
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+  }
+
+  @Test
+  fun getNewUid_returnsGeneratedId() {
+    `when`(mockDocumentReference.id).thenReturn("1")
+    val uid = lessonRepositoryFirestore.getNewUid()
+    assert(uid == "1")
+  }
+
+  @Test
+  fun addLesson_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+
+    lessonRepositoryFirestore.addLesson(lesson, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun updateLesson_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+
+    lessonRepositoryFirestore.updateLesson(lesson, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun deleteLesson_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+    lessonRepositoryFirestore.deleteLesson(lesson.id, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun documentToLesson_returnsValidLesson() {
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("title")).thenReturn("Physics Tutoring")
+    `when`(mockDocumentSnapshot.getString("description")).thenReturn("Mechanics")
+    `when`(mockDocumentSnapshot.getString("subject")).thenReturn("PHYSICS")
+    `when`(mockDocumentSnapshot.getString("tutorUid")).thenReturn("tutor123")
+    `when`(mockDocumentSnapshot.getString("studentUid")).thenReturn("student123")
+    `when`(mockDocumentSnapshot.getDouble("minPrice")).thenReturn(20.0)
+    `when`(mockDocumentSnapshot.getDouble("maxPrice")).thenReturn(40.0)
+    `when`(mockDocumentSnapshot.getString("timeSlot")).thenReturn("2024-10-10T10:00:00")
+    `when`(mockDocumentSnapshot.getString("status")).thenReturn("PENDING")
+    `when`(mockDocumentSnapshot.getString("language")).thenReturn("ENGLISH")
+
+    val result = lessonRepositoryFirestore.documentToLesson(mockDocumentSnapshot)
+
+    assert(result != null)
+    assert(result!!.title == "Physics Tutoring")
+    assert(result.subject == TutoringSubject.PHYSICS)
+    assert(result.minPrice == 20.0)
+    assert(result.maxPrice == 40.0)
+    assert(result.status == LessonStatus.PENDING)
+    assert(result.language == "ENGLISH")
+  }
+
+  @Test
+  fun documentToLesson_returnsNullOnInvalidData() {
+    `when`(mockDocumentSnapshot.getString("title")).thenReturn(null) // Invalid data
+
+    val result = lessonRepositoryFirestore.documentToLesson(mockDocumentSnapshot)
+
+    assert(result == null)
+  }
+}

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
@@ -1,9 +1,9 @@
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.lesson.Lesson
-import com.android.sample.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonRepositoryFirestore
-import com.github.se.project.model.profile.TutoringSubject
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.profile.Subject
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.CollectionReference
@@ -36,7 +36,7 @@ class LessonRepositoryFirestoreTest {
           id = "1",
           title = "Physics Tutoring",
           description = "Mechanics",
-          subject = TutoringSubject.PHYSICS,
+          subject = Subject.PHYSICS,
           tutorUid = "tutor123",
           studentUid = "student123",
           minPrice = 20.0,
@@ -116,7 +116,7 @@ class LessonRepositoryFirestoreTest {
 
     assert(result != null)
     assert(result!!.title == "Physics Tutoring")
-    assert(result.subject == TutoringSubject.PHYSICS)
+    assert(result.subject == Subject.PHYSICS)
     assert(result.minPrice == 20.0)
     assert(result.maxPrice == 40.0)
     assert(result.status == LessonStatus.PENDING)

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.github.se.project.model.lesson
+
+import com.android.sample.model.lesson.Lesson
+import com.android.sample.model.lesson.LessonStatus
+import com.github.se.project.model.profile.TutoringSubject
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+
+class LessonViewModelTest {
+  private lateinit var lessonRepository: LessonRepository
+  private lateinit var lessonViewModel: LessonViewModel
+
+  private val lesson =
+      Lesson(
+          id = "1",
+          title = "Physics Tutoring",
+          description = "Mechanics and Thermodynamics",
+          subject = TutoringSubject.PHYSICS,
+          tutorUid = "tutor123",
+          studentUid = "student123",
+          minPrice = 20.0,
+          maxPrice = 40.0,
+          timeSlot = "2024-10-10T10:00:00",
+          status = LessonStatus.PENDING,
+          language = "ENGLISH")
+
+  @Before
+  fun setUp() {
+    lessonRepository = mock(LessonRepository::class.java)
+    lessonViewModel = LessonViewModel(lessonRepository)
+  }
+
+  @Test
+  fun getNewUidCallsRepository() {
+    `when`(lessonRepository.getNewUid()).thenReturn("newUid")
+    assertThat(lessonViewModel.getNewUid(), `is`("newUid"))
+  }
+
+  @Test
+  fun addLessonCallsRepository() {
+    lessonViewModel.addLesson(lesson) {}
+    verify(lessonRepository).addLesson(eq(lesson), any(), any())
+  }
+
+  @Test
+  fun deleteLessonCallsRepository() {
+    lessonViewModel.deleteLesson(lesson.id) {}
+    verify(lessonRepository).deleteLesson(eq(lesson.id), any(), any())
+  }
+
+  @Test
+  fun selectLessonUpdatesSelectedLesson() {
+    lessonViewModel.selectLesson(lesson)
+    assertThat(lessonViewModel.selectedLesson.value, `is`(lesson))
+  }
+
+  @Test
+  fun getLessonsForTutorCallsRepository() {
+    lessonViewModel.getLessonsForTutor("tutor123") {}
+    verify(lessonRepository).getLessonsForTutor(eq("tutor123"), any(), any())
+  }
+
+  @Test
+  fun getLessonsForStudentCallsRepository() {
+    lessonViewModel.getLessonsForStudent("student123") {}
+    verify(lessonRepository).getLessonsForStudent(eq("student123"), any(), any())
+  }
+
+  @Test
+  fun getLessonsForTutorUpdatesStateFlow() = runBlocking {
+    val lessons = listOf(lesson)
+    val onSuccessCaptor = argumentCaptor<(List<Lesson>) -> Unit>()
+
+    lessonViewModel.getLessonsForTutor("tutor123") {}
+    verify(lessonRepository).getLessonsForTutor(eq("tutor123"), onSuccessCaptor.capture(), any())
+    onSuccessCaptor.firstValue.invoke(lessons)
+
+    val collectedLessons = lessonViewModel.currentUserLessons.value
+    assertThat(collectedLessons, `is`(lessons))
+  }
+
+  @Test
+  fun getLessonsForStudentUpdatesStateFlow() = runBlocking {
+    val lessons = listOf(lesson)
+    val onSuccessCaptor = argumentCaptor<(List<Lesson>) -> Unit>()
+
+    lessonViewModel.getLessonsForStudent("student123") {}
+    verify(lessonRepository)
+        .getLessonsForStudent(eq("student123"), onSuccessCaptor.capture(), any())
+    onSuccessCaptor.firstValue.invoke(lessons)
+
+    val collectedLessons = lessonViewModel.currentUserLessons.value
+    assertThat(collectedLessons, `is`(lessons))
+  }
+}

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
@@ -1,8 +1,6 @@
 package com.github.se.project.model.lesson
 
-import com.android.sample.model.lesson.Lesson
-import com.android.sample.model.lesson.LessonStatus
-import com.github.se.project.model.profile.TutoringSubject
+import com.github.se.project.model.profile.Subject
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -24,7 +22,7 @@ class LessonViewModelTest {
           id = "1",
           title = "Physics Tutoring",
           description = "Mechanics and Thermodynamics",
-          subject = TutoringSubject.PHYSICS,
+          subject = Subject.PHYSICS,
           tutorUid = "tutor123",
           studentUid = "student123",
           minPrice = 20.0,


### PR DESCRIPTION
### PR Title: Add Unit Tests for LessonRepositoryFirestore and LessonViewModel

## Description
This very short PR adds two new unit tests for the lesson model, including the FireStore repository and its view model

## File modified
1. `LessonRepositoryFirestore` : I had to add the @ VisibleForTesting to be able to test the private function documentToLesson()

## Files added
3. `LessonViewModel` :
getNewUidCallsRepository: Verifies getNewUid() calls the repository.
addLessonCallsRepository: Ensures addLesson() calls the repository.
deleteLessonCallsRepository: Confirms deleteLesson() calls the repository.
selectLessonUpdatesSelectedLesson: Checks selectLesson() updates the selected lesson.
getLessonsForTutor/StudentCallsRepository: Verifies fetching lessons calls the repository.
getLessonsForTutor/StudentUpdatesStateFlow: Confirms state flow updates with fetched lessons. 

5. `LessonRepositoryFirestore`:
getNewUid_returnsGeneratedId: Verifies getNewUid() returns a generated ID.
addLesson_shouldCallFirestoreCollection: Ensures addLesson() calls Firestore.
updateLesson_shouldCallFirestoreCollection: Confirms updateLesson() calls Firestore.
deleteLesson_shouldCallFirestoreCollection: Verifies deleteLesson() calls Firestore.
documentToLesson_returnsValidLesson: Tests valid conversion from Firestore document to Lesson.
documentToLesson_returnsNullOnInvalidData: Ensures documentToLesson() returns null for invalid data.

## Note
With those tests, I could attain 91% of coverage for the `LessonViewModel` and only 60% for the `LessonRepositoryFirestore`. This is due to the fact that we (me and @LeaBlancher) did not figure out a way to test the functions calling functions from FireStore (for example, the getLessonForTutor function in `LessonRepositoryFirestore`)... hope we'll find a solution soon!

linked issue: #54 