### PR TITLE
test/80 coverage milestone 1

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/components/SubjectSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/components/SubjectSelectorTest.kt
@@ -1,0 +1,36 @@
+package com.github.se.project.ui.components
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.project.model.profile.Subject
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SubjectSelectorTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun selectingSubjectsUpdatesCorrectly() {
+    val subjects = mutableStateOf<Subject>(Subject.NONE)
+    composeTestRule.setContent { SubjectSelector(subjects) }
+
+    Subject.entries.forEach { subject ->
+      if (subject == Subject.NONE) return@forEach
+      composeTestRule.onNodeWithTag("dropdownItem-${subject.name}").isNotDisplayed()
+    }
+    composeTestRule.onNodeWithTag("subjectButton").performClick()
+
+    Subject.entries.forEach { subject ->
+      if (subject == Subject.NONE) return@forEach
+      composeTestRule.onNodeWithTag("dropdownItem-${subject.name}").assertIsDisplayed()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/project/ui/components/writableDropdown.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/components/writableDropdown.kt
@@ -2,6 +2,7 @@ package com.github.se.project.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -47,5 +48,21 @@ class WritableDropdownTest {
 
     // Check that the value is updated
     assert(currentValue == "A")
+  }
+
+  @Test
+  fun testDropdownChoices() {
+    var currentValue = ""
+    composeTestRule.setContent {
+      WritableDropdown(
+          label = "Select Item",
+          placeholder = "Choose an option",
+          value = currentValue,
+          onValueChange = { currentValue = it },
+          choices = listOf("Apple", "Banana", "Cherry"))
+    }
+
+    composeTestRule.onNodeWithTag("dropdown").performTextInput("A")
+    composeTestRule.onNodeWithTag("item_Apple").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/project/ui/profile/CreateTutorProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/profile/CreateTutorProfileTest.kt
@@ -1,25 +1,31 @@
 package com.github.se.project.ui.profile
 
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performGesture
+import androidx.compose.ui.test.swipeRight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.project.model.profile.AcademicLevel
 import com.github.se.project.model.profile.Language
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.model.profile.Profile
-import com.github.se.project.model.profile.ProfilesRepository
 import com.github.se.project.model.profile.Role
 import com.github.se.project.model.profile.Section
 import com.github.se.project.model.profile.Subject
 import com.github.se.project.ui.components.LanguageSelector
 import com.github.se.project.ui.navigation.NavigationActions
-import java.util.EnumSet
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class CreateTutorProfileTest {
@@ -116,6 +122,23 @@ class CreateTutorProfileTest {
   }
 
   @Test
+  fun selectingSubjectsUpdatesCorrectly() {
+    val subjects = mutableListOf<Subject>()
+    composeTestRule.setContent { SubjectsSelector(subjects) }
+
+    Subject.entries.forEach { subject ->
+      if (subject == Subject.NONE) return@forEach
+      composeTestRule.onNodeWithTag("dropdown${subject.name}").isNotDisplayed()
+    }
+    composeTestRule.onNodeWithTag("subjectButton").performClick()
+
+    Subject.entries.forEach { subject ->
+      if (subject == Subject.NONE) return@forEach
+      composeTestRule.onNodeWithTag("dropdown${subject.name}").assertIsDisplayed()
+    }
+  }
+
+  @Test
   fun sliderTextTest() {
     (mockViewModel.currentProfile as MutableStateFlow).value =
         Profile(
@@ -158,49 +181,5 @@ class CreateTutorProfileTest {
     composeTestRule
         .onNodeWithTag("noProfile")
         .assertTextEquals("No Profile selected. Should not happen.")
-  }
-}
-
-class MockProfilesRepository : ProfilesRepository {
-  private val profiles = mutableListOf<Profile>()
-
-  override fun init(onSuccess: () -> Unit) {
-    onSuccess()
-  }
-
-  override fun getNewUid(): String {
-    return "mockUid"
-  }
-
-  override fun getProfiles(onSuccess: (List<Profile>) -> Unit, onFailure: (Exception) -> Unit) {
-    onSuccess(profiles)
-  }
-
-  override fun addProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    profiles.add(profile)
-    onSuccess()
-  }
-
-  override fun updateProfile(
-      profile: Profile,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    val index = profiles.indexOfFirst { it.uid == profile.uid }
-    if (index != -1) {
-      profiles[index] = profile
-      onSuccess()
-    } else {
-      onFailure(Exception("Profile not found"))
-    }
-  }
-
-  override fun deleteProfileById(
-      id: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    onSuccess() // This not deleting anything is not a problem: this class is only used to test
-    // adding profiles
   }
 }

--- a/app/src/androidTest/java/com/github/se/project/ui/profile/CreateTutorProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/profile/CreateTutorProfileTest.kt
@@ -20,12 +20,12 @@ import com.github.se.project.model.profile.Section
 import com.github.se.project.model.profile.Subject
 import com.github.se.project.ui.components.LanguageSelector
 import com.github.se.project.ui.navigation.NavigationActions
+import java.util.EnumSet
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class CreateTutorProfileTest {
@@ -38,9 +38,6 @@ class CreateTutorProfileTest {
       Mockito.mock(ListProfilesViewModel::class.java).apply {
         Mockito.`when`(currentProfile).thenReturn(MutableStateFlow<Profile?>(null))
       }
-  // list of languages
-  private val languages = Language.entries.toTypedArray()
-  private val subjects = Subject.entries.toTypedArray()
 
   @Test
   fun createTutorProfileScreen_rendersCorrectly() {


### PR DESCRIPTION
# Add tests (unit and UI) to achieve 80% of coverage

### PR Description
This PR adds more test additionnaly to the one implemented in the PR #47, #52,  #56, and #57. The goal is to achieve 80% of code line coverage before the Milestone 1.

### New tests
- in CreateTutorProfileTest, to test if the drop down menu for the subject selection is displayed correctly
- in writableDropDown, to test if the items are wee displayed when entering the beginning of the item we want to select
- in a new file SubjectSelectorTest, to test the component SubjetSelector and in particularly to test if all the items of the menu are well displayed

### How to test this PR
To test the PR, it is sufficient to run the test that I added. One could also run the jococoReport to confirm that it reaches 80%line coverage.

#### Note
I made this PR on the base of PR #56 so that it will be easy to merge and also in order that I can easily run the test with all the tests we have written. However, these 2 PR do not modify the same test files so it should not casue any issue when merging.