### PR TITLE
setup/fix-ci

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -119,3 +119,13 @@ jobs:
         with:
           name: Coverage report
           path: app/build/reports/jacoco/jacocoTestReport
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.coverageReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+            -Dsonar.projectKey=PocketTutor-Team_pockettutor-app
+            -Dsonar.organization=pockettutor-team
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.login=${{ secrets.SONAR_TOKEN }}     

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # First step : Checkout the repository on the runner
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis (if we use Sonar Later)
@@ -47,7 +47,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
@@ -58,7 +58,7 @@ jobs:
       #
       # To avoid that, we cache the the gradle folder to reuse it later.
       - name: Retrieve gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -132,8 +132,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.coverageReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+            -Dsonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
             -Dsonar.projectKey=PocketTutor-Team_pockettutor-app
             -Dsonar.organization=pockettutor-team
             -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.login=${{ secrets.SONAR_TOKEN }}     
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }}     

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -90,6 +90,12 @@ jobs:
           # To run the CI with debug information, add --info
           ./gradlew assembleDebug lint --parallel --build-cache
 
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: APK
+          path: app/build/outputs/apk/debug/app-debug.apk
+
       - name: Run tests
         run: |
           # To run the CI with debug information, add --info

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -122,6 +122,8 @@ jobs:
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
             -Dsonar.coverageReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml


### PR DESCRIPTION
# Fix the CI to integrate SonarCloud scan and the APK

### PR Description 
After the milestone 1, we find out that we have some bugs with our CI workflow. This PR updates the CI workflow according to this correction (cf list right after).

#### Element added to the CI workflow
- Integrate Sonar Cloud  scan  so that we add the coverage report in SonarCloud
- Integrate the updload of the APK file so that we can access it at the same place as the jacoco report (in Actions section of the repository)
- Update the version of the github actions because of github migration form Node.js16 to Node.js20

**Note:** To integrate SonarCloud scan, I added a repository secret SONAR_TOKEN which is the token used by Sonar Cloud to run the scan.