### PR TITLE
setup/fix-ci (PR#2)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - setup/fix-ci
 
   pull_request:
     types:
@@ -137,4 +138,5 @@ jobs:
             -Dsonar.organization=pockettutor-team
             -Dsonar.sources=app/src/main/java/com/github/se/project
             -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }}     
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }} 
+            -Dsonar.branch.name=${{ github.ref_name }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - setup/fix-ci
 
   pull_request:
     types:
@@ -139,4 +138,3 @@ jobs:
             -Dsonar.sources=app/src/main/java/com/github/se/project
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} 
-            -Dsonar.branch.name=${{ github.ref_name }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -135,5 +135,6 @@ jobs:
             -Dsonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
             -Dsonar.projectKey=PocketTutor-Team_pockettutor-app
             -Dsonar.organization=pockettutor-team
+            -Dsonar.sources=app/src/main/java/com/github/se/project
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.token=${{ secrets.SONAR_TOKEN }}     

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -135,6 +135,7 @@ jobs:
             -Dsonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
             -Dsonar.projectKey=PocketTutor-Team_pockettutor-app
             -Dsonar.organization=pockettutor-team
-            -Dsonar.sources=app/src/main/java/com/github/se/project
+            -Dsonar.sources=app/src/main/java
+            -Dsonar.tests=app/src/test/java,app/src/androidTest/java
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} 


### PR DESCRIPTION
# Fix SonarCloud coverage computation

### PR description
This PR aims to fix the SonarCloud coverage computation so that the coverage in Sonar Cloud is the same as the line coverage we use to reach 80%.

#### Corrections made:
- Add the specification of the source code directory so that SonarCloud doesn't count the test files as code line to cover.

**NB:** There are some analysis that are performed only when merging to the main and this is why I found issues after merging and I needed to update the setup. Sorry for the inconvenience.