### PR TITLE
Feature/requested lesson screen implementation

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -121,8 +121,6 @@ class LessonsRequestedScreenTest {
 
     // Click on the DatePicker to ensure it can be interacted with
     composeTestRule.onNodeWithTag("datePicker").performClick()
-    // Here you would add further interactions if you can simulate date selection in the test
-    // environment
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -1,0 +1,169 @@
+package com.github.se.project.ui.lesson
+
+import LessonsRequestedScreen
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.se.project.model.lesson.Lesson
+import com.github.se.project.model.lesson.LessonRepository
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.*
+import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Route
+import com.github.se.project.ui.navigation.TopLevelDestinations
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class LessonsRequestedScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var listProfilesViewModel: ListProfilesViewModel
+  private lateinit var lessonViewModel: LessonViewModel
+  private lateinit var navigationActions: NavigationActions
+
+  private val profile =
+      Profile(
+          "uid",
+          "googleUid",
+          "firstName",
+          "lastName",
+          "phoneNumber",
+          Role.TUTOR,
+          Section.AR,
+          AcademicLevel.BA1,
+          listOf(Language.ENGLISH),
+          listOf(Subject.ANALYSIS),
+          List(7) { List(12) { 0 } },
+          0)
+
+  private val mockLessons =
+      listOf(
+          Lesson(
+              id = "1",
+              title = "Physics Tutoring",
+              description = "Mechanics and Thermodynamics",
+              subject = Subject.PHYSICS,
+              languages = listOf(Language.ENGLISH),
+              tutorUid = "tutor123",
+              studentUid = "student123",
+              minPrice = 20.0,
+              maxPrice = 40.0,
+              timeSlot = "2024-10-10T10:00:00",
+              status = LessonStatus.REQUESTED),
+          Lesson(
+              id = "2",
+              title = "Math Tutoring",
+              description = "Algebra and Calculus",
+              subject = Subject.ANALYSIS,
+              languages = listOf(Language.ENGLISH),
+              tutorUid = "tutor123",
+              studentUid = "student123",
+              minPrice = 20.0,
+              maxPrice = 40.0,
+              timeSlot = "2024-10-10T11:00:00",
+              status = LessonStatus.REQUESTED))
+  private val requestedLessonsFlow = MutableStateFlow(mockLessons)
+
+  @Before
+  fun setup() {
+    // Mock the ViewModels
+    listProfilesViewModel =
+        Mockito.mock(ListProfilesViewModel::class.java).apply {
+          `when`(currentProfile).thenReturn(MutableStateFlow(profile))
+        }
+
+    val mockRepository = mock(LessonRepository::class.java)
+    lessonViewModel =
+        Mockito.spy(LessonViewModel(mockRepository)).apply {
+          `when`(this.requestedLessons).thenReturn(requestedLessonsFlow)
+        }
+
+    navigationActions =
+        Mockito.mock(NavigationActions::class.java).apply {
+          `when`(currentRoute()).thenReturn(Route.FIND_STUDENT)
+        }
+  }
+
+  @Test
+  fun testScreenComponentsDisplayed() {
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Verify Top Bar and Bottom Navigation are displayed
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+  }
+
+  @Test
+  fun testLessonItemsDisplayed() {
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Verify the lesson items are displayed
+    composeTestRule.onNodeWithText("Physics Tutoring").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Math Tutoring").assertIsDisplayed()
+  }
+
+  @Test
+  fun testDatePickerButtonFunctionality() {
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Click on the DatePicker to ensure it can be interacted with
+    composeTestRule.onNodeWithTag("datePicker").performClick()
+    // Here you would add further interactions if you can simulate date selection in the test
+    // environment
+  }
+
+  @Test
+  fun testLessonsFilteredBySelectedDate() {
+    // Set the selected date to filter lessons
+    val filteredDate = "2024-10-10"
+
+    // Change the lessons to include only those that match the date
+    requestedLessonsFlow.value = mockLessons.filter { it.timeSlot.contains(filteredDate) }
+
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Verify that only the filtered lesson items are displayed
+    composeTestRule.onNodeWithText("Physics Tutoring").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Math Tutoring").assertIsDisplayed()
+  }
+
+  @Test
+  fun testBottomNavigationSelection() {
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Interact with Bottom Navigation and verify navigation action
+    composeTestRule.onNodeWithTag("Find a Student").performClick()
+
+    // Verify using the actual TopLevelDestination object
+    verify(navigationActions).navigateTo(TopLevelDestinations.TUTOR)
+  }
+
+  @Test
+  fun testNoLessonsMessageDisplayedWhenEmpty() {
+    requestedLessonsFlow.value = emptyList() // Set no lessons
+
+    composeTestRule.setContent {
+      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Verify "No lessons available" message or any placeholder is displayed
+    composeTestRule.onNodeWithTag("noLessonsMessage").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -1,6 +1,6 @@
 package com.github.se.project.ui.lesson
 
-import LessonsRequestedScreen
+import RequestedLessonsScreen
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.project.model.lesson.Lesson
@@ -94,7 +94,7 @@ class LessonsRequestedScreenTest {
   @Test
   fun testScreenComponentsDisplayed() {
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Verify Top Bar and Bottom Navigation are displayed
@@ -105,7 +105,7 @@ class LessonsRequestedScreenTest {
   @Test
   fun testLessonItemsDisplayed() {
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Verify the lesson items are displayed
@@ -116,7 +116,7 @@ class LessonsRequestedScreenTest {
   @Test
   fun testDatePickerButtonFunctionality() {
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Click on the DatePicker to ensure it can be interacted with
@@ -132,7 +132,7 @@ class LessonsRequestedScreenTest {
     requestedLessonsFlow.value = mockLessons.filter { it.timeSlot.contains(filteredDate) }
 
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Verify that only the filtered lesson items are displayed
@@ -143,7 +143,7 @@ class LessonsRequestedScreenTest {
   @Test
   fun testBottomNavigationSelection() {
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Interact with Bottom Navigation and verify navigation action
@@ -158,7 +158,7 @@ class LessonsRequestedScreenTest {
     requestedLessonsFlow.value = emptyList() // Set no lessons
 
     composeTestRule.setContent {
-      LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
     // Verify "No lessons available" message or any placeholder is displayed

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.github.se.project
 
+import LessonsRequestedScreen
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -110,11 +111,14 @@ fun PocketTutorApp() {
     }
 
     navigation(
-        startDestination = Screen.HOME,
+        startDestination = Screen.LESSONS_REQUESTED,
         route = Route.FIND_STUDENT,
     ) {
       composable(Screen.HOME) {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      }
+      composable(Screen.LESSONS_REQUESTED) {
+        LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
     }
 

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.github.se.project
 
-import LessonsRequestedScreen
+import RequestedLessonsScreen
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -118,7 +118,7 @@ fun PocketTutorApp() {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
       composable(Screen.LESSONS_REQUESTED) {
-        LessonsRequestedScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+        RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
     }
 

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -21,6 +21,9 @@ interface LessonRepository {
       onFailure: (Exception) -> Unit
   )
 
+  // Method to retrieve all requested lessons of the database
+  fun getAllRequestedLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit)
+
   // Method to add a new lesson
   fun addLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -27,6 +27,28 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
     }
   }
 
+  override fun getAllRequestedLessons(
+      onSuccess: (List<Lesson>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("status", LessonStatus.REQUESTED.name)
+        .get()
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful) {
+            val lessons =
+                task.result?.documents?.mapNotNull { document -> documentToLesson(document) }
+                    ?: emptyList()
+            onSuccess(lessons)
+          } else {
+            task.exception?.let { e ->
+              Log.e("LessonRepositoryFirestore", "Error getting requested lessons", e)
+              onFailure(e)
+            }
+          }
+        }
+  }
+
   // General method to retrieve lessons based on a user field (tutor or student)
   private fun getLessonsByUserField(
       userField: String,

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 open class LessonViewModel(private val repository: LessonRepository) : ViewModel() {
 
+  private val requestedLessons_ = MutableStateFlow<List<Lesson>>(emptyList())
+  open val requestedLessons: StateFlow<List<Lesson>> = requestedLessons_.asStateFlow()
+
   private val currentUserLessons_ = MutableStateFlow<List<Lesson>>(emptyList())
   open val currentUserLessons: StateFlow<List<Lesson>> = currentUserLessons_.asStateFlow()
 
@@ -129,6 +132,23 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
         onFailure = {
           Log.e("LessonViewModel", "Error fetching student's lessons", it)
           onComplete() // Call the callback even if there's a failure
+        })
+  }
+
+  /**
+   * Fetches all lessons with the specified status from the repository.
+   *
+   * @param onComplete Callback to execute when the operation completes.
+   */
+  fun getAllRequestedLessons(onComplete: () -> Unit = {}) {
+    repository.getAllRequestedLessons(
+        onSuccess = { fetchedLessons ->
+          requestedLessons_.value = fetchedLessons
+          onComplete()
+        },
+        onFailure = {
+          Log.e("LessonViewModel", "Error fetching lessons by status", it)
+          onComplete()
         })
   }
 }

--- a/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
@@ -104,6 +104,7 @@ fun LessonsRequestedTopBar(selectedDate: LocalDate?, onDateSelected: (LocalDate)
           calendar.get(Calendar.YEAR),
           calendar.get(Calendar.MONTH),
           calendar.get(Calendar.DAY_OF_MONTH))
+  datePickerDialog.datePicker.minDate = Calendar.getInstance().timeInMillis
 
   TopAppBar(
       title = {

--- a/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
@@ -27,7 +27,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 
 @Composable
-fun LessonsRequestedScreen(
+fun RequestedLessonsScreen(
     listProfilesViewModel: ListProfilesViewModel =
         viewModel(factory = ListProfilesViewModel.Factory),
     lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),

--- a/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
@@ -1,0 +1,124 @@
+import android.app.DatePickerDialog
+import android.util.Log
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.model.profile.Role
+import com.github.se.project.ui.components.DisplayLessons
+import com.github.se.project.ui.navigation.BottomNavigationMenu
+import com.github.se.project.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS_TUTOR
+import com.github.se.project.ui.navigation.NavigationActions
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Calendar
+
+@Composable
+fun LessonsRequestedScreen(
+    listProfilesViewModel: ListProfilesViewModel =
+        viewModel(factory = ListProfilesViewModel.Factory),
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
+    navigationActions: NavigationActions
+) {
+  // Update requested lessons each time we arrive on this screen
+  LaunchedEffect(Unit) { lessonViewModel.getAllRequestedLessons(onComplete = {}) }
+
+  val currentProfile by listProfilesViewModel.currentProfile.collectAsState()
+  val requestedLessons by lessonViewModel.requestedLessons.collectAsState()
+  var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+
+  // Filter and sort lessons by the selected date, if a date is selected
+  val filteredLessons =
+      requestedLessons
+          .filter { lesson ->
+            selectedDate == null || parseLessonDate(lesson.timeSlot)?.toLocalDate() == selectedDate
+          }
+          .sortedBy { parseLessonDate(it.timeSlot) }
+
+  Scaffold(
+      topBar = { LessonsRequestedTopBar(selectedDate) { newDate -> selectedDate = newDate } },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATIONS_TUTOR,
+            selectedItem = navigationActions.currentRoute())
+      }) { innerPadding ->
+        DisplayLessons(
+            modifier = Modifier.padding(innerPadding),
+            lessons = filteredLessons,
+            isTutor = (currentProfile?.role == Role.TUTOR))
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LessonsRequestedTopBar(selectedDate: LocalDate?, onDateSelected: (LocalDate) -> Unit) {
+  val context = LocalContext.current
+  val dateFormatter = DateTimeFormatter.ofPattern("dd/MM")
+
+  // Date picker dialog setup
+  val calendar = Calendar.getInstance()
+  val datePickerDialog =
+      DatePickerDialog(
+          context,
+          { _, year, month, dayOfMonth ->
+            val newDate = LocalDate.of(year, month + 1, dayOfMonth)
+            onDateSelected(newDate)
+          },
+          calendar.get(Calendar.YEAR),
+          calendar.get(Calendar.MONTH),
+          calendar.get(Calendar.DAY_OF_MONTH))
+
+  TopAppBar(
+      title = {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Text(text = "Lessons Requested")
+          Spacer(modifier = Modifier.width(8.dp))
+          Surface(
+              shape = RoundedCornerShape(8.dp),
+              color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+              modifier = Modifier.clickable { datePickerDialog.show() }) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+                      Icon(
+                          imageVector = Icons.Default.DateRange,
+                          contentDescription = "Calendar",
+                          tint = MaterialTheme.colorScheme.primary)
+                      Spacer(modifier = Modifier.width(4.dp))
+                      Text(text = selectedDate?.format(dateFormatter) ?: "Select Date")
+                    }
+              }
+        }
+      },
+      actions = {
+        IconButton(onClick = { /* TODO: Additional filter options */}) {
+          Icon(imageVector = Icons.Outlined.Menu, contentDescription = "Filter")
+        }
+      })
+}
+
+// Updated parseLessonDate function to return LocalDateTime for sorting by date and time
+fun parseLessonDate(timeSlot: String): LocalDateTime? {
+  return try {
+    val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy'T'HH:mm:ss")
+    LocalDateTime.parse(timeSlot, formatter)
+  } catch (e: Exception) {
+    Log.e("parseLessonDate", "Error parsing date: $timeSlot", e)
+    null
+  }
+}

--- a/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
@@ -28,6 +28,7 @@ object Screen {
   const val CALENDAR = "Calendar Screen"
   const val ADD_LESSON = "Add Lesson Screen"
   const val CREATE_TUTOR_SCHEDULE = "Create tutor calendar Screen"
+  const val LESSONS_REQUESTED = "Lessons Requested Screen"
   const val SEARCH = "Search Screen" // Find tutor / find student screen
 }
 


### PR DESCRIPTION
## PR Description:

This pull request introduces the `RequestedLessonsScreen` and includes (small) updates to the `MainActivity` for navigation, the `LessonViewModel` for retrieving all requested lessons, and the `LessonRepositoryFirestore` to retrieve all requested lessons of the FireStore DB. The new screen allows tutors to view and filter lessons requested by students, with navigation integrated through a bottom navigation menu and filtering lessons by date (with a date picker). The option to further filter lessons is not implemented yet since I am not sure which filter we would like to use (and also there was no relevant filter icon, but I still put one on the top right corner)

## Summary of changes

**Files Modified:**

1. **MainActivity.kt**
   - Added a new composable navigation for the `RequestedLessonsScreen` and linked it to the `Screen.LESSONS_REQUESTED` route.
  
2. **LessonRepository.kt**
   - Added a new method `getAllRequestedLessons` to this interface, to fetch all requested lessons

3. **LessonRepositoryFirestore.kt**
   - Implemented `getAllRequestedLessons` to retrieve lessons with a `REQUESTED` status.

4. **LessonViewModel.kt**
   - Added a new `requestedLessons` state flow to store and observe requested lessons (that I can collect as a state in the `RequestedLessonsScreen`)
   - Implemented `getAllRequestedLessons` to fetch and update the `requestedLessons` flow.
  
5. **RequestedLessons.kt**
   - Created the `RequestedLessonsScreen` composable to display requested lessons.
   - Integrated a `TopAppBar` with a date picker for filtering and a bottom navigation menu.
   - Added logic to filter lessons by date and display a message when no lessons are available.
   - Applied margins and alignments for a polished UI layout.

6. **NavigationActions.kt**
   - Added a new `Screen.LESSONS_REQUESTED` constant to facilitate navigation to the `RequestedLessonsScreen`.

7 **RequestedLessonTest.kt**
- Added some very basics test, which achieve 77% of coverage. We could do more but since this screen might have some minor changes I did not want to spend too much time on those tests :)

## How to Test
You should be logged in as a TUTOR to be able to test this screen (since it appears only on the tutor's side). You can always modify manually your account in the FiresTore to set your account as TUTOR. 
Also, there are already many lessons we added in the past few weeks on the data base, which you can show in the filter by commenting the line 107 of **RequestedLesson.kt** ("// datePickerDialog.datePicker.minDate = Calendar.getInstance().timeInMillis") which prevent filter selecting date in the past. Otherwise you could just add a bunch of lessons in the future or modify the lessons date manually in the data base :)

## ScreenShots

when we arrive on the screen, every REQUESTED lessons appears (sorted chronologically). There is no date filtering at this stage.
<img width="331" alt="image" src="https://github.com/user-attachments/assets/39fca4c4-b2ee-4f28-99f2-c96a73103253">

when we select a date that has no lesson, a short message is displayed
<img width="331" alt="image" src="https://github.com/user-attachments/assets/32a9418c-1b55-4c5f-9f00-59c3e7ab1355">

when we have a few lesson corresponding to a certain date, they appear
<img width="331" alt="image" src="https://github.com/user-attachments/assets/7ecda00f-d09c-473e-b04a-d4542ff329bf">


## PS
I experienced a bug in the sign in (in my branch but also in the actual main branch), which sometimes ask me to create an account even if I already have one. When I recompile the code, it recognise my account. Let me know if it is only on my side or also on yours so that we can find a solution :)
