### PR TITLE
Feature/tutor response screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
@@ -60,7 +60,7 @@ class HomeScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T10:00:00",
-              status = LessonStatus.PENDING),
+              status = LessonStatus.TUTOR_REQUESTED),
           Lesson(
               id = "2",
               title = "Math Tutoring",
@@ -72,7 +72,7 @@ class HomeScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T11:00:00",
-              status = LessonStatus.PENDING))
+              status = LessonStatus.STUDENT_REQUESTED))
   private val currentUserLessonsFlow = MutableStateFlow<List<Lesson>>(mockLessons)
 
   @Before

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -20,6 +20,7 @@ import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.ui.authentification.SignInScreen
 import com.github.se.project.ui.lesson.AddLessonScreen
+import com.github.se.project.ui.lesson.TutorLessonResponseScreen
 import com.github.se.project.ui.navigation.NavigationActions
 import com.github.se.project.ui.navigation.Route
 import com.github.se.project.ui.navigation.Screen
@@ -119,6 +120,9 @@ fun PocketTutorApp() {
       }
       composable(Screen.LESSONS_REQUESTED) {
         RequestedLessonsScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      }
+      composable(Screen.TUTOR_LESSON_RESPONSE) {
+        TutorLessonResponseScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
     }
 

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
@@ -3,7 +3,9 @@ package com.github.se.project.model.lesson
 // Enum class to define lesson status
 enum class LessonStatus {
   REQUESTED,
-  PENDING, // Lesson is pending
+  PENDING, // Lesson is pending => TODO: Remove it and use STUDENT_PENDING and TUTOR_PENDING
+  TUTOR_PENDING, // Lesson is pending and wait for tutor to confirm
+  STUDENT_PENDING, // Lesson is pending and wait for student to confirm
   CONFIRMED, // Lesson is confirmed
   COMPLETED, // Lesson has been completed
   CANCELLED // Lesson has been cancelled

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
@@ -2,10 +2,11 @@ package com.github.se.project.model.lesson
 
 // Enum class to define lesson status
 enum class LessonStatus {
-  REQUESTED,
-  PENDING, // Lesson is pending => TODO: Remove it and use STUDENT_PENDING and TUTOR_PENDING
-  TUTOR_PENDING, // Lesson is pending and wait for tutor to confirm
-  STUDENT_PENDING, // Lesson is pending and wait for student to confirm
+  REQUESTED, // Lesson has been requested => TODO: remove this (replaced by STUDENT_REQUESTED and
+  // TUTOR_REQUESTED)
+  STUDENT_REQUESTED, // Lesson has been requested by student => need to be confirmed by the tutor
+  TUTOR_REQUESTED, // Lesson has been requested by tutor => need to be confirmed by the student
+  PENDING, // Lesson is pending => need to find a tutor
   CONFIRMED, // Lesson is confirmed
   COMPLETED, // Lesson has been completed
   CANCELLED // Lesson has been cancelled

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -68,6 +68,24 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
   }
 
   /**
+   * Updates an existing lesson in the repository.
+   *
+   * @param lesson The Lesson object to be updated.
+   * @param onComplete Callback to execute when the operation completes.
+   */
+  fun updateLesson(lesson: Lesson, onComplete: () -> Unit) {
+    repository.updateLesson(
+        lesson = lesson,
+        onSuccess = {
+          onComplete() // Call the provided callback on success
+        },
+        onFailure = {
+          Log.e("LessonViewModel", "Error updating lesson: $lesson", it)
+          onComplete() // Call the callback even if there's a failure
+        })
+  }
+
+  /**
    * Deletes a lesson from the repository.
    *
    * @param lessonId The ID of the lesson to be deleted.

--- a/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
@@ -53,6 +53,17 @@ open class ListProfilesViewModel(private val repository: ProfilesRepository) : V
   }
 
   /**
+   * Gets a Profile document by its ID.
+   *
+   * @param id The ID of the Profile document to be retrieved.
+   * @return The Profile document with the given ID, or null if not found.
+   */
+  fun getProfileById(id: String): Profile? {
+    getProfiles()
+    return profiles_.value.find { it.uid == id }
+  }
+
+  /**
    * Adds a Profile document.
    *
    * @param profile The Profile document to be added.

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayLessonDetails.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayLessonDetails.kt
@@ -1,11 +1,18 @@
 package com.github.se.project.ui.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.profile.Profile
 
@@ -14,30 +21,53 @@ fun DisplayLessonDetails(
     lesson: Lesson,
     studentProfile: Profile,
 ) {
-  Column(
-      modifier = Modifier.fillMaxSize(),
-      content = {
-        // Student information
-        Row(
+  Card(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(vertical = 2.dp)
+              .testTag("lessonDetailsCard"), // Tag for each lesson card
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceBright)) {
+        Column(
             content = {
-              // TODO: Add profile image
-
-              // Name and Academic Level
-              Column(
+              // Student information
+              Row(
+                  modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceBetween,
                   content = {
-                    Text(studentProfile.firstName + studentProfile.lastName)
-                    Text(
-                        studentProfile.section.toString() +
-                            " " +
-                            studentProfile.academicLevel.toString())
+                    // TODO: Add profile image
+
+                    // Name and Academic Level
+                    Column(
+                        content = {
+                          Text(
+                              studentProfile.firstName + studentProfile.lastName,
+                              style = MaterialTheme.typography.titleMedium,
+                              modifier = Modifier.testTag("studentName"))
+                          Text(
+                              studentProfile.section.toString() +
+                                  " " +
+                                  studentProfile.academicLevel.toString(),
+                              style = MaterialTheme.typography.bodyMedium,
+                          )
+                        })
+
+                    // Price range
+                    Text(lesson.minPrice.toString() + ".-/" + lesson.maxPrice.toString() + ".-")
                   })
 
-              // Price range
-              Text(lesson.minPrice.toString() + ".-/" + lesson.maxPrice.toString() + ".-")
+              // Lesson details
+              Column(
+                  modifier = Modifier.padding(16.dp),
+              ) {
+                Text(
+                    lesson.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.testTag("lessonTitle"))
+                Text(
+                    lesson.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.testTag("lessonDescription"))
+              }
             })
-
-        // Lesson details
-        Text(lesson.title)
-        Text(lesson.description)
-      })
+      }
 }

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayLessonDetails.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayLessonDetails.kt
@@ -1,0 +1,43 @@
+package com.github.se.project.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.github.se.project.model.lesson.Lesson
+import com.github.se.project.model.profile.Profile
+
+@Composable
+fun DisplayLessonDetails(
+    lesson: Lesson,
+    studentProfile: Profile,
+) {
+  Column(
+      modifier = Modifier.fillMaxSize(),
+      content = {
+        // Student information
+        Row(
+            content = {
+              // TODO: Add profile image
+
+              // Name and Academic Level
+              Column(
+                  content = {
+                    Text(studentProfile.firstName + studentProfile.lastName)
+                    Text(
+                        studentProfile.section.toString() +
+                            " " +
+                            studentProfile.academicLevel.toString())
+                  })
+
+              // Price range
+              Text(lesson.minPrice.toString() + ".-/" + lesson.maxPrice.toString() + ".-")
+            })
+
+        // Lesson details
+        Text(lesson.title)
+        Text(lesson.description)
+      })
+}

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
@@ -1,5 +1,6 @@
 package com.github.se.project.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -25,7 +26,8 @@ fun DisplayLessons(
     modifier: Modifier = Modifier,
     lessons: List<Lesson>,
     statusFilter: LessonStatus? = null, // Option to filter by status
-    isTutor: Boolean
+    isTutor: Boolean,
+    onCardClick: (Lesson) -> Unit = {}
 ) {
   val filteredLessons =
       statusFilter?.let { lessons.filter { lesson -> lesson.status == it } } ?: lessons
@@ -36,7 +38,8 @@ fun DisplayLessons(
           modifier =
               Modifier.fillMaxWidth()
                   .padding(vertical = 2.dp)
-                  .testTag("lessonCard_$index"), // Tag for each lesson card
+                  .testTag("lessonCard_$index")
+                  .clickable { onCardClick(lesson) }, // Tag for each lesson card
           colors =
               CardDefaults.cardColors(
                   containerColor =

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -129,7 +129,7 @@ fun LessonEditor(
               maxPrice,
               0.0,
               "${selectedDate}T${selectedTime}:00",
-              LessonStatus.REQUESTED,
+              LessonStatus.PENDING,
           ))
     }
   }

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -91,7 +91,7 @@ fun AddLessonScreen(
               maxPrice,
               0.0,
               "${selectedDate}T${selectedTime}:00",
-              LessonStatus.REQUESTED,
+              LessonStatus.PENDING,
           ),
           onComplete = {
             lessonViewModel.getLessonsForStudent(profile.value!!.uid, onComplete = {})

--- a/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
@@ -21,6 +21,7 @@ import com.github.se.project.ui.components.DisplayLessons
 import com.github.se.project.ui.navigation.BottomNavigationMenu
 import com.github.se.project.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS_TUTOR
 import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Screen
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -80,7 +81,11 @@ fun RequestedLessonsScreen(
                         .fillMaxWidth()
                         .testTag("lessonsList"),
                 lessons = filteredLessons,
-                isTutor = (currentProfile?.role == Role.TUTOR))
+                isTutor = (currentProfile?.role == Role.TUTOR),
+                onCardClick = { lesson ->
+                  lessonViewModel.selectLesson(lesson)
+                  navigationActions.navigateTo(Screen.TUTOR_LESSON_RESPONSE)
+                })
           }
         }
       }

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -2,21 +2,24 @@ package com.github.se.project.ui.lesson
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Scaffold
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -41,31 +44,35 @@ fun TutorLessonResponseScreen(
       lessonViewModel.selectedLesson.collectAsState().value
           ?: return Text("No lesson selected. Should not happen.")
 
-  val sliderPrice = remember { mutableFloatStateOf(lesson.price.toFloat()) }
+  val sliderPrice = remember {
+    mutableFloatStateOf(((lesson.maxPrice - lesson.minPrice).toFloat() / 2.0).toFloat())
+  }
 
   val context = LocalContext.current
 
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = {
+        Row(
+            modifier = Modifier.testTag("topBar").fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              IconButton(onClick = { navigationActions.goBack() }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back arrow",
+                    modifier = Modifier.size(32.dp).testTag("backButton"))
+              }
+
               Text(
-                  "Respond to the request", modifier = Modifier.testTag("TutorLessonResponseTitle"))
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("TutorLessonResponseBackButton")) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back")
-                  }
-            })
+                  text = "Respond to the request",
+                  style = MaterialTheme.typography.headlineMedium,
+                  modifier = Modifier.testTag("TutorLessonResponseTitle"))
+            }
       },
       content = { paddingValues ->
         Column(
             modifier =
                 Modifier.fillMaxSize()
+                    .padding(16.dp)
                     .padding(paddingValues)
                     .testTag("tutorLessonResponseScreen")) {
               val studentProfile = listProfilesViewModel.getProfileById(lesson.studentUid)

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -35,10 +35,10 @@ import com.github.se.project.ui.navigation.Screen
 
 @Composable
 fun TutorLessonResponseScreen(
-    navigationActions: NavigationActions,
     listProfilesViewModel: ListProfilesViewModel =
         viewModel(factory = ListProfilesViewModel.Factory),
-    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory)
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
+    navigationActions: NavigationActions,
 ) {
   val lesson =
       lessonViewModel.selectedLesson.collectAsState().value
@@ -99,7 +99,7 @@ fun TutorLessonResponseScreen(
                   lesson.copy(
                       tutorUid = listProfilesViewModel.currentProfile.value!!.uid,
                       price = sliderPrice.floatValue.toDouble(),
-                      status = LessonStatus.TUTOR_PENDING),
+                      status = LessonStatus.TUTOR_REQUESTED),
                   onComplete = {
                     lessonViewModel.getLessonsForTutor(
                         listProfilesViewModel.currentProfile.value!!.uid)

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -1,0 +1,105 @@
+package com.github.se.project.ui.lesson
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.ui.components.DisplayLessonDetails
+import com.github.se.project.ui.components.PriceSlider
+import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Screen
+
+@Composable
+fun TutorLessonResponseScreen(
+    navigationActions: NavigationActions,
+    listProfilesViewModel: ListProfilesViewModel =
+        viewModel(factory = ListProfilesViewModel.Factory),
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory)
+) {
+  val lesson =
+      lessonViewModel.selectedLesson.collectAsState().value
+          ?: return Text("No lesson selected. Should not happen.")
+
+  val sliderPrice = remember { mutableFloatStateOf(lesson.price.toFloat()) }
+
+  val context = LocalContext.current
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Text(
+                  "Respond to the request", modifier = Modifier.testTag("TutorLessonResponseTitle"))
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("TutorLessonResponseBackButton")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back")
+                  }
+            })
+      },
+      content = { paddingValues ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(paddingValues)
+                    .testTag("tutorLessonResponseScreen")) {
+              val studentProfile = listProfilesViewModel.getProfileById(lesson.studentUid)
+              if (studentProfile == null) {
+                Toast.makeText(
+                        context,
+                        "Cannot retrieve student profile for the given lesson",
+                        Toast.LENGTH_SHORT)
+                    .show()
+                Text("ERROR: Cannot retrieve student profile for the chosen lesson")
+              } else {
+                DisplayLessonDetails(lesson, studentProfile)
+              }
+
+              PriceSlider(sliderPrice)
+            }
+      },
+      bottomBar = {
+        Button(
+            modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("confirmButton"),
+            onClick = {
+              // Update the lesson price and status and tutorUid
+              lessonViewModel.updateLesson(
+                  lesson.copy(
+                      tutorUid = listProfilesViewModel.currentProfile.value!!.uid,
+                      price = sliderPrice.floatValue.toDouble(),
+                      status = LessonStatus.TUTOR_PENDING),
+                  onComplete = {
+                    lessonViewModel.getLessonsForTutor(
+                        listProfilesViewModel.currentProfile.value!!.uid)
+                    navigationActions.navigateTo(Screen.HOME)
+                  })
+            }) {
+              Text("Offer yourself for this lesson")
+            }
+      })
+}

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -45,7 +45,8 @@ fun TutorLessonResponseScreen(
           ?: return Text("No lesson selected. Should not happen.")
 
   val sliderPrice = remember {
-    mutableFloatStateOf(((lesson.maxPrice - lesson.minPrice).toFloat() / 2.0).toFloat())
+    mutableFloatStateOf(
+        (lesson.maxPrice.toFloat() - lesson.minPrice.toFloat()) / 2.0f + lesson.minPrice.toFloat())
   }
 
   val context = LocalContext.current
@@ -98,7 +99,7 @@ fun TutorLessonResponseScreen(
               lessonViewModel.updateLesson(
                   lesson.copy(
                       tutorUid = listProfilesViewModel.currentProfile.value!!.uid,
-                      price = sliderPrice.floatValue.toDouble(),
+                      price = sliderPrice.floatValue.toInt().toDouble(),
                       status = LessonStatus.TUTOR_REQUESTED),
                   onComplete = {
                     lessonViewModel.getLessonsForTutor(

--- a/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
@@ -29,6 +29,7 @@ object Screen {
   const val ADD_LESSON = "Add Lesson Screen"
   const val CREATE_TUTOR_SCHEDULE = "Create tutor calendar Screen"
   const val LESSONS_REQUESTED = "Lessons Requested Screen"
+  const val TUTOR_LESSON_RESPONSE = "Tutor Lesson Response Screen"
   const val SEARCH = "Search Screen" // Find tutor / find student screen
 }
 

--- a/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
@@ -85,7 +85,8 @@ fun HomeScreen(
 
           if (lessons.any {
             it.status == LessonStatus.CONFIRMED ||
-                it.status == LessonStatus.REQUESTED ||
+                it.status == LessonStatus.STUDENT_REQUESTED ||
+                it.status == LessonStatus.TUTOR_REQUESTED ||
                 it.status == LessonStatus.PENDING
           }) {
             Column(
@@ -98,8 +99,9 @@ fun HomeScreen(
                   if (profile.role == Role.TUTOR) {
                     ExpandableLessonSection(
                         sectionTitle = "Pending Lessons",
+                        // we have selected it and wait for student confirmation
                         lessons = lessons,
-                        statusFilter = LessonStatus.PENDING,
+                        statusFilter = LessonStatus.TUTOR_REQUESTED,
                         isTutor = true,
                         maxHeight = 340.dp,
                         modifier = Modifier.testTag("pendingLessonsSection"))
@@ -117,12 +119,22 @@ fun HomeScreen(
                   if (profile.role == Role.STUDENT) {
                     ExpandableLessonSection(
                         sectionTitle = "Requested Lessons",
+                        // we have create a lesson but no match yet
                         lessons = lessons,
-                        statusFilter = LessonStatus.REQUESTED,
+                        statusFilter = LessonStatus.STUDENT_REQUESTED,
                         isTutor = false,
                         maxHeight = 340.dp,
                         modifier = Modifier.testTag("requestedLessonsSection"))
                     Spacer(modifier = Modifier.height(16.dp))
+
+                    ExpandableLessonSection(
+                        sectionTitle = "To Confirm Lessons",
+                        // a tutor has selected the lesson and wait for student confirmation
+                        lessons = lessons,
+                        statusFilter = LessonStatus.TUTOR_REQUESTED,
+                        isTutor = false,
+                        maxHeight = 340.dp,
+                        modifier = Modifier.testTag("toConfirmLessonsStudentSection"))
 
                     ExpandableLessonSection(
                         sectionTitle = "Confirmed Lessons",


### PR DESCRIPTION
# Implement the TutorResponseLesson screen so that tutor can accept a pending lesson

### PR Description
This PR add the screen TutorResponseLesson (see an example of it UI at the end of the description). It also implement navigation to this screen from the RequestedLesson screen.
Moreover it also update the LessonState with the state needed to complete the lifecycle of a lesson. You can have a look at the Lesson State diagram that is in the wiki to see how we go from one state to another.

### Modified files
- MainActivity.kt => update the navigation to be able to navigate to the TutorResponseLesson screen
- LessonStatus.kt => update the lesson status with the separation of the requested state when it is a student who made the request and when it is a tutor
- LessonViewModel.kt => fix a merge problem with the main (doesn't make any new updates)
- ListProfilesViewModel.kt => add a function to get the profile with a given uid, the ultimate goal of this update is to be able to put the list of all profiles private and only access some of the profiles
- DisplayLessonDetails.kt => add a component to display the lesson details, we will be able to reuse it when a tutor need to validate a requested lesson
- DisplayLesson.kt => add onClick to be able to add the navigation to TutorResponseLesson screen from the RequestedLesson screen
- LessonEditor.kt => fix the state of the lesson at the creation of it
- RequestedLesson.kt => add navigation to rge TutorResponseLesson screen when click on a lesson is triggered
- TutorLessonresponse.kt => the main new screen implemented in this PR
- NavigationsActions.kt => add a screen value for the TutorResponseLesson screen
- Overview.kt => update the category of lessons that are displayed with the updated lesson states
- OverViewTest.kt => fix the status of the lessons used for testing because pending lessons are not displayed for tutor (because pending means that there is no tutor assigned)

### How to test this PR
The tests for this screen are not yet available but you can already run the MainActivity with a Tutor profile and go to the "Find a student" section and select a Lesson to see the screen and interact with it.

### Screen example
![image](https://github.com/user-attachments/assets/215bbd4b-0736-43ca-9e57-b6f63b4f1dbc)