### PR TITLE
Fix/edit lesson

### DIFF
--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -118,7 +118,7 @@ fun LessonEditor(
     } else {
       onConfirm(
           Lesson(
-              lesson!!.id,
+              lesson?.id ?: "",
               title,
               description,
               selectedSubject.value,


### PR DESCRIPTION
Fix the `onComplete` callback in `LessonEditor` to address a bug that occurs when creating a new lesson.