### PR TITLE
small bug fix: overview not displaying added lessons

### DIFF
--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -118,7 +118,7 @@ fun LessonEditor(
     } else {
       onConfirm(
           Lesson(
-              lesson!!.id,
+              lesson?.id ?: "",
               title,
               description,
               selectedSubject.value,
@@ -129,7 +129,7 @@ fun LessonEditor(
               maxPrice,
               0.0,
               "${selectedDate}T${selectedTime}:00",
-              LessonStatus.PENDING,
+              LessonStatus.STUDENT_REQUESTED,
           ))
     }
   }


### PR DESCRIPTION
## PR Description

This pull request addresses a bug in the `LessonEditor` component that prevented lessons from being displayed in the overview when adding a lesson (as a Student profile). The issue was caused by filtering lessons using the wrong`LessonStatus.PENDING` status, whereas the correct status should be `LessonStatus.STUDENT_REQUESTED`, recently introduced by @LeaBlancher . 

## Summary of Changes

**File changed**

- **LessonEditor.kt**
  - Changed the filter from `LessonStatus.PENDING` to `LessonStatus.STUDENT_REQUESTED` to ensure that lessons requested by students are properly displayed in the overview.
  - Applied the fix that was causing a crash when adding a lesson (introduce by @Philipp0206  in PR #76 )

## How to Test

You can juste create an account as a Student and try adding a lesson. It should be displayed directly after under the "Requested lessons" field.
You can see an example below, it should be displayed this way:

<img width="284" alt="image" src="https://github.com/user-attachments/assets/6dbbf654-bf2b-495a-9251-b51e9a5a9092">

