### PR TITLE
fix: price range slider initialisation and update

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
@@ -51,7 +51,7 @@ class AddLessonTest {
   @Test
   fun sliderTest() {
     var changed = false
-    composeTestRule.setContent { PriceRangeSlider("testLabel") { a, b -> changed = true } }
+    composeTestRule.setContent { PriceRangeSlider("testLabel", { a, b -> changed = true }) }
     composeTestRule.onNodeWithTag("priceRangeSlider").performTouchInput { swipeRight() }
     assert(changed)
   }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -233,10 +233,14 @@ fun LessonEditor(
 
               Spacer(modifier = Modifier.height(8.dp))
 
-              PriceRangeSlider("Select a price range for your lesson:") { min, max ->
-                minPrice = min.toDouble()
-                maxPrice = max.toDouble()
-              }
+              PriceRangeSlider(
+                  "Select a price range for your lesson:",
+                  { min, max ->
+                    minPrice = min.toDouble()
+                    maxPrice = max.toDouble()
+                  },
+                  initialStart = minPrice.toFloat(),
+                  initialEnd = maxPrice.toFloat())
 
               Text("Selected price range: ${minPrice.toInt()}.- to ${maxPrice.toInt()}.-")
             }

--- a/app/src/main/java/com/github/se/project/ui/components/PriceRangeSlider.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/PriceRangeSlider.kt
@@ -14,8 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 
 @Composable
-fun PriceRangeSlider(label: String, onValueChange: (Float, Float) -> Unit) {
-  var sliderPosition by remember { mutableStateOf(0f..100f) }
+fun PriceRangeSlider(
+    label: String,
+    onValueChange: (Float, Float) -> Unit,
+    initialStart: Float = 5f, // Default value for initialStart
+    initialEnd: Float = 50f,
+) {
+  var sliderPosition by remember { mutableStateOf(initialStart..initialEnd) }
 
   Column(modifier = Modifier.testTag("priceRangeSliderColumn")) {
     Text(
@@ -26,11 +31,11 @@ fun PriceRangeSlider(label: String, onValueChange: (Float, Float) -> Unit) {
     RangeSlider(
         value = sliderPosition,
         steps = 44,
-        onValueChange = { range -> sliderPosition = range },
-        valueRange = 5f..50f,
-        onValueChangeFinished = {
+        onValueChange = { range ->
+          sliderPosition = range
           onValueChange(sliderPosition.start, sliderPosition.endInclusive)
         },
+        valueRange = 5f..50f,
         colors =
             SliderDefaults.colors(
                 thumbColor = MaterialTheme.colorScheme.secondaryContainer,


### PR DESCRIPTION
## PR Description

This pull request fixes two issues related to the `PriceRangeSlider` in the `LessonEditor` component, which caused confusion. 
1: The first problem was that when we arrive on the screen with a price range slider, there were no initial values so they the tip were always all the way to the end of the slider. 
2: The second problem was that it was not updating smoothly, we had to release the click to know what price we were currently on. 

## Summary of Changes

**Files changed**

- **PriceRangeSlider.kt**
  - Added two optional parameters, `initialStart` and `initialEnd`, to set the initial positions of the slider thumbs based on the current min and max prices. This resolves the issue number 1.
  - Updated the `RangeSlider` to call `onValueChange` inside the `onValueChange` lambda. This solves issue number 2.

- **LessonEditor.kt**
  - Passed the lesson's min and max prices to `PriceRangeSlider` using the new `initialStart` and `initialEnd` parameters, ensuring the slider thumbs are correctly set on screen load.

- **AddLEssonTest.kt**
- Updated the call to PriceRangeSlider to use correctly the new header of the composable.

## Screen recordings of the behaviour
I will show the Screen of lesson editor as an example to demonstrate the behaviour of the price range slider (before and after the bug fix).

- Before bug fix:

https://github.com/user-attachments/assets/5158d71c-3a1c-4d24-b770-4da6d1c626de

- After bug fix:

https://github.com/user-attachments/assets/fa4c66ab-8ca3-44ad-a0a4-c9d0e81826bb



