### PR TITLE
fix/scroll conflict between column and map in MapPickerBox

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
@@ -66,8 +66,8 @@ class AddLessonTest {
             listOf(Language.ENGLISH),
             "date",
             "time",
-            0.0,
-            0.0) == null)
+            1.0,
+            1.0) == null)
     assert(
         validateLessonInput(
             "title",
@@ -76,8 +76,8 @@ class AddLessonTest {
             listOf(Language.ENGLISH),
             "date",
             "",
-            0.0,
-            0.0) == "time is missing")
+            1.0,
+            1.0) == "time is missing")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
@@ -65,7 +65,9 @@ class AddLessonTest {
             mutableStateOf(Subject.AICC),
             listOf(Language.ENGLISH),
             "date",
-            "time") == null)
+            "time",
+            0.0,
+            0.0) == null)
     assert(
         validateLessonInput(
             "title",
@@ -73,7 +75,10 @@ class AddLessonTest {
             mutableStateOf(Subject.AICC),
             listOf(Language.ENGLISH),
             "date",
-            "") == "time is missing")
+            "",
+            0.0,
+            0.0
+            ) == "time is missing")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
@@ -77,8 +77,7 @@ class AddLessonTest {
             "date",
             "",
             0.0,
-            0.0
-            ) == "time is missing")
+            0.0) == "time is missing")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -56,7 +56,10 @@ class LessonsRequestedScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T10:00:00",
-              status = LessonStatus.REQUESTED),
+              status = LessonStatus.REQUESTED,
+              latitude = 0.0,
+                longitude = 0.0
+              ),
           Lesson(
               id = "2",
               title = "Math Tutoring",
@@ -68,7 +71,10 @@ class LessonsRequestedScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T11:00:00",
-              status = LessonStatus.REQUESTED))
+              status = LessonStatus.REQUESTED,
+                latitude = 0.0,
+                    longitude = 0.0
+          ))
   private val requestedLessonsFlow = MutableStateFlow(mockLessons)
 
   @Before

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -58,8 +58,7 @@ class LessonsRequestedScreenTest {
               timeSlot = "2024-10-10T10:00:00",
               status = LessonStatus.REQUESTED,
               latitude = 0.0,
-                longitude = 0.0
-              ),
+              longitude = 0.0),
           Lesson(
               id = "2",
               title = "Math Tutoring",
@@ -72,9 +71,8 @@ class LessonsRequestedScreenTest {
               maxPrice = 40.0,
               timeSlot = "2024-10-10T11:00:00",
               status = LessonStatus.REQUESTED,
-                latitude = 0.0,
-                    longitude = 0.0
-          ))
+              latitude = 0.0,
+              longitude = 0.0))
   private val requestedLessonsFlow = MutableStateFlow(mockLessons)
 
   @Before

--- a/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
@@ -60,7 +60,10 @@ class HomeScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T10:00:00",
-              status = LessonStatus.TUTOR_REQUESTED),
+              status = LessonStatus.TUTOR_REQUESTED,
+              latitude = 0.0,
+              longitude = 0.0
+              ),
           Lesson(
               id = "2",
               title = "Math Tutoring",
@@ -72,7 +75,10 @@ class HomeScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T11:00:00",
-              status = LessonStatus.STUDENT_REQUESTED))
+              status = LessonStatus.STUDENT_REQUESTED,
+              latitude = 0.0,
+                longitude = 0.0
+              ))
   private val currentUserLessonsFlow = MutableStateFlow<List<Lesson>>(mockLessons)
 
   @Before

--- a/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/overview/OverViewTest.kt
@@ -62,8 +62,7 @@ class HomeScreenTest {
               timeSlot = "2024-10-10T10:00:00",
               status = LessonStatus.TUTOR_REQUESTED,
               latitude = 0.0,
-              longitude = 0.0
-              ),
+              longitude = 0.0),
           Lesson(
               id = "2",
               title = "Math Tutoring",
@@ -77,8 +76,7 @@ class HomeScreenTest {
               timeSlot = "2024-10-10T11:00:00",
               status = LessonStatus.STUDENT_REQUESTED,
               latitude = 0.0,
-                longitude = 0.0
-              ))
+              longitude = 0.0))
   private val currentUserLessonsFlow = MutableStateFlow<List<Lesson>>(mockLessons)
 
   @Before

--- a/app/src/androidTest/java/com/github/se/project/ui/profile/LessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/profile/LessonTest.kt
@@ -12,7 +12,10 @@ class LessonTest {
 
   @Test
   fun testLessonDefaultValues() {
-    val lesson = Lesson()
+    val lesson = Lesson(
+        latitude = 0.0,
+        longitude = 0.0
+    )
     assertEquals("", lesson.id)
     assertEquals("", lesson.title)
     assertEquals("", lesson.description)
@@ -24,6 +27,8 @@ class LessonTest {
     assertEquals("", lesson.timeSlot)
     assertEquals(LessonStatus.PENDING, lesson.status)
     assertEquals(listOf<Language>(), lesson.languages)
+      assertEquals(0.0, lesson.latitude)
+        assertEquals(0.0, lesson.longitude)
   }
 
   @Test
@@ -40,7 +45,9 @@ class LessonTest {
             maxPrice = 100.0,
             timeSlot = "2024-10-10T10:00:00",
             status = LessonStatus.CONFIRMED,
-            languages = listOf(Language.ENGLISH))
+            languages = listOf(Language.ENGLISH),
+            latitude = 0.0,
+            longitude = 0.0)
     assertEquals("1", lesson.id)
     assertEquals("Kotlin Basics", lesson.title)
     assertEquals("Introduction to Kotlin", lesson.description)
@@ -52,6 +59,8 @@ class LessonTest {
     assertEquals("2024-10-10T10:00:00", lesson.timeSlot)
     assertEquals(LessonStatus.CONFIRMED, lesson.status)
     assertEquals(listOf(Language.ENGLISH), lesson.languages)
+    assertEquals(0.0, lesson.latitude)
+    assertEquals(0.0, lesson.longitude)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/profile/LessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/profile/LessonTest.kt
@@ -12,10 +12,7 @@ class LessonTest {
 
   @Test
   fun testLessonDefaultValues() {
-    val lesson = Lesson(
-        latitude = 0.0,
-        longitude = 0.0
-    )
+    val lesson = Lesson(latitude = 0.0, longitude = 0.0)
     assertEquals("", lesson.id)
     assertEquals("", lesson.title)
     assertEquals("", lesson.description)
@@ -27,8 +24,8 @@ class LessonTest {
     assertEquals("", lesson.timeSlot)
     assertEquals(LessonStatus.PENDING, lesson.status)
     assertEquals(listOf<Language>(), lesson.languages)
-      assertEquals(0.0, lesson.latitude)
-        assertEquals(0.0, lesson.longitude)
+    assertEquals(0.0, lesson.latitude)
+    assertEquals(0.0, lesson.longitude)
   }
 
   @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+            <meta-data
+                android:name="com.google.android.geo.API_KEY"
+                android:value="${MAPS_API_KEY}" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.github.se.project
 
+import MapPickerScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -108,9 +109,12 @@ fun PocketTutorApp() {
     }
 
     navigation(
-        startDestination = Screen.HOME,
+        startDestination = Screen.MAP_LOC_PICKER,
         route = Route.FIND_STUDENT,
     ) {
+      composable(Screen.MAP_LOC_PICKER) {
+        MapPickerScreen(lessonViewModel, navigationActions)
+      }
       composable(Screen.HOME) {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
@@ -134,6 +138,9 @@ fun PocketTutorApp() {
       }
       composable(Screen.ADD_LESSON) {
         AddLessonScreen(navigationActions, listProfilesViewModel, lessonViewModel)
+      }
+      composable(Screen.MAP_LOC_PICKER) {
+        MapPickerScreen(lessonViewModel, navigationActions)
       }
       // composable(Screen.EDIT_LESSON) {
       //  EditLessonScreen(listProfilesViewModel, lessonViewModel, navigationActions)

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -112,9 +112,7 @@ fun PocketTutorApp() {
         startDestination = Screen.MAP_LOC_PICKER,
         route = Route.FIND_STUDENT,
     ) {
-      composable(Screen.MAP_LOC_PICKER) {
-        MapPickerScreen(lessonViewModel, navigationActions)
-      }
+      composable(Screen.MAP_LOC_PICKER) { MapPickerScreen(lessonViewModel, navigationActions) }
       composable(Screen.HOME) {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
@@ -139,9 +137,7 @@ fun PocketTutorApp() {
       composable(Screen.ADD_LESSON) {
         AddLessonScreen(navigationActions, listProfilesViewModel, lessonViewModel)
       }
-      composable(Screen.MAP_LOC_PICKER) {
-        MapPickerScreen(lessonViewModel, navigationActions)
-      }
+      composable(Screen.MAP_LOC_PICKER) { MapPickerScreen(lessonViewModel, navigationActions) }
       // composable(Screen.EDIT_LESSON) {
       //  EditLessonScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       // }

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.github.se.project
 
-import MapPickerScreen
 import RequestedLessonsScreen
 import android.content.pm.ActivityInfo
 import android.os.Bundle
@@ -119,7 +118,6 @@ fun PocketTutorApp() {
         startDestination = Screen.LESSONS_REQUESTED,
         route = Route.FIND_STUDENT,
     ) {
-      composable(Screen.MAP_LOC_PICKER) { MapPickerScreen(lessonViewModel, navigationActions) }
       composable(Screen.HOME) {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
@@ -147,7 +145,6 @@ fun PocketTutorApp() {
       composable(Screen.ADD_LESSON) {
         AddLessonScreen(navigationActions, listProfilesViewModel, lessonViewModel)
       }
-      composable(Screen.MAP_LOC_PICKER) { MapPickerScreen(lessonViewModel, navigationActions) }
       // composable(Screen.EDIT_LESSON) {
       //  EditLessonScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       // }

--- a/app/src/main/java/com/github/se/project/model/lesson/Lesson.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/Lesson.kt
@@ -16,6 +16,6 @@ data class Lesson(
     val price: Double = 0.0, // Price for the lesson
     val timeSlot: String = "", // Time slot for the lesson (e.g., "30/10/2024T10:00:00")
     val status: LessonStatus = LessonStatus.PENDING, // Status of the lesson
-    val latitude: Double = 46.518867, // Latitude for lesson location
-    val longitude: Double = 6.568257 // Longitude for lesson location
+    val latitude: Double, // Latitude for lesson location
+    val longitude: Double // Longitude for lesson location
 )

--- a/app/src/main/java/com/github/se/project/model/lesson/Lesson.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/Lesson.kt
@@ -16,4 +16,6 @@ data class Lesson(
     val price: Double = 0.0, // Price for the lesson
     val timeSlot: String = "", // Time slot for the lesson (e.g., "2024-10-10T10:00:00")
     val status: LessonStatus = LessonStatus.PENDING, // Status of the lesson
+    val latitude: Double = 46.518867, // Latitude for lesson location
+    val longitude: Double = 6.568257 // Longitude for lesson location
 )

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -158,6 +158,8 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
       val price = document.getDouble("price") ?: return null
       val timeSlot = document.getString("timeSlot") ?: return null
       val status = LessonStatus.valueOf(document.getString("status") ?: return null)
+        val latitude = document.getDouble("latitude") ?: return null
+        val longitude = document.getDouble("longitude") ?: return null
 
       val language =
           document.get("languages")?.let { languagesList ->
@@ -183,7 +185,9 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
           maxPrice,
           price,
           timeSlot,
-          status)
+          status,
+            latitude,
+            longitude)
     } catch (e: Exception) {
       Log.e("LessonRepositoryFirestore", "Error converting document to Lesson", e)
       null

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -158,8 +158,8 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
       val price = document.getDouble("price") ?: return null
       val timeSlot = document.getString("timeSlot") ?: return null
       val status = LessonStatus.valueOf(document.getString("status") ?: return null)
-        val latitude = document.getDouble("latitude") ?: return null
-        val longitude = document.getDouble("longitude") ?: return null
+      val latitude = document.getDouble("latitude") ?: return null
+      val longitude = document.getDouble("longitude") ?: return null
 
       val language =
           document.get("languages")?.let { languagesList ->
@@ -186,8 +186,8 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
           price,
           timeSlot,
           status,
-            latitude,
-            longitude)
+          latitude,
+          longitude)
     } catch (e: Exception) {
       Log.e("LessonRepositoryFirestore", "Error converting document to Lesson", e)
       null

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -21,20 +21,19 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
   private val _selectedLesson = MutableStateFlow<Lesson?>(null)
   open val selectedLesson: StateFlow<Lesson?> = _selectedLesson.asStateFlow()
 
-    // StateFlow to observe selected location changes
-    //Default value is currently set to Lausanne EPFL
-    //TODO: Change default value to user's current location
-    private val _selectedLocation = MutableStateFlow<Pair<Double, Double>>(46.520374 to 6.568339)
-    val selectedLocation = _selectedLocation.asStateFlow()
+  // StateFlow to observe selected location changes
+  // Default value is currently set to Lausanne EPFL
+  // TODO: Change default value to user's current location
+  private val _selectedLocation = MutableStateFlow<Pair<Double, Double>>(46.520374 to 6.568339)
+  val selectedLocation = _selectedLocation.asStateFlow()
 
-    // Function to update location
-    fun updateSelectedLocation(location: Pair<Double, Double>) {
-        _selectedLocation.value = location
-    }
+  // Function to update location
+  fun updateSelectedLocation(location: Pair<Double, Double>) {
+    _selectedLocation.value = location
+  }
 
   init {
-    repository.init {
-    }
+    repository.init {}
   }
 
   /** Factory for creating a LessonsViewModel. */

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -15,17 +15,25 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 open class LessonViewModel(private val repository: LessonRepository) : ViewModel() {
 
-  private val currentUserLessons_ = MutableStateFlow<List<Lesson>>(emptyList())
-  open val currentUserLessons: StateFlow<List<Lesson>> = currentUserLessons_.asStateFlow()
+  private val _currentUserLessons = MutableStateFlow<List<Lesson>>(emptyList())
+  open val currentUserLessons: StateFlow<List<Lesson>> = _currentUserLessons.asStateFlow()
 
-  private val selectedLesson_ = MutableStateFlow<Lesson?>(null)
-  open val selectedLesson: StateFlow<Lesson?> = selectedLesson_.asStateFlow()
+  private val _selectedLesson = MutableStateFlow<Lesson?>(null)
+  open val selectedLesson: StateFlow<Lesson?> = _selectedLesson.asStateFlow()
+
+    // StateFlow to observe selected location changes
+    //Default value is currently set to Lausanne EPFL
+    //TODO: Change default value to user's current location
+    private val _selectedLocation = MutableStateFlow<Pair<Double, Double>>(46.520374 to 6.568339)
+    val selectedLocation = _selectedLocation.asStateFlow()
+
+    // Function to update location
+    fun updateSelectedLocation(location: Pair<Double, Double>) {
+        _selectedLocation.value = location
+    }
 
   init {
     repository.init {
-      // Uncomment this if needed in the future to automatically load lessons, but this seems to
-      // make the CI fails.
-      // getAllLessons()
     }
   }
 
@@ -91,7 +99,7 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
    * @param lesson The Lesson object to be selected.
    */
   fun selectLesson(lesson: Lesson) {
-    selectedLesson_.value = lesson
+    _selectedLesson.value = lesson
   }
 
   /**
@@ -104,7 +112,7 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
     repository.getLessonsForTutor(
         tutorUid = tutorUid,
         onSuccess = { fetchedLessons ->
-          currentUserLessons_.value = fetchedLessons
+          _currentUserLessons.value = fetchedLessons
           onComplete() // Call the provided callback on success
         },
         onFailure = {
@@ -123,7 +131,7 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
     repository.getLessonsForStudent(
         studentUid = studentUid,
         onSuccess = { fetchedLessons ->
-          currentUserLessons_.value = fetchedLessons
+          _currentUserLessons.value = fetchedLessons
           onComplete() // Call the provided callback on success
         },
         onFailure = {

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -220,17 +220,6 @@ fun LessonEditor(
                           style = MaterialTheme.typography.labelMedium)
                     }
               }
-              Button(
-                  onClick = { timePickerDialog.show() },
-                  modifier = Modifier.weight(1f).testTag("TimeButton"),
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                          contentColor = MaterialTheme.colorScheme.onSecondaryContainer)) {
-                    Text(
-                        selectedTime.ifEmpty { "Select Time" },
-                        style = MaterialTheme.typography.labelMedium)
-                  }
             }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -132,7 +132,7 @@ fun LessonEditor(
       Log.d("LessonEditor", lesson?.id ?: "Lesson is null")
       onConfirm(
           Lesson(
-              lesson!!.id,
+              lesson?.id ?: "",
               title,
               description,
               selectedSubject.value,

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -4,7 +4,6 @@ import MapPickerBox
 import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -235,7 +234,7 @@ fun LessonEditor(
 
               // Toggle button for Map Picker
               Button(onClick = { isMapVisible = !isMapVisible }) {
-                Text(if (isMapVisible) "Hide Map" else "Pick Location on Map")
+                Text(if (isMapVisible) "Hide Map" else "Display the Map")
               }
 
               // Display selected location coordinates

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -1,5 +1,6 @@
 package com.github.se.project.ui.components
 
+import MapPickerBox
 import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
@@ -29,7 +30,6 @@ import java.util.Calendar
 fun LessonEditor(
     mainTitle: String,
     profile: Profile,
-    selectedLocation: Pair<Double, Double>,
     lesson: Lesson?,
     onBack: () -> Unit,
     onLocationPicker: () -> Unit,
@@ -48,6 +48,15 @@ fun LessonEditor(
   val calendar = Calendar.getInstance()
   val currentDateTime = Calendar.getInstance()
   val currentLessonId = remember { mutableStateOf<String?>(null) }
+
+  var selectedLocation by remember {
+    mutableStateOf(lesson?.let { it.latitude to it.longitude } ?: (46.520374 to 6.568339))
+  }
+  var isMapVisible by remember { mutableStateOf(false) }
+  val onLocationSelected: (Pair<Double, Double>) -> Unit = { newLocation ->
+    selectedLocation = newLocation
+    isMapVisible = false // Hide map after confirming selection
+  }
 
   if (currentLessonId.value != lesson?.id) {
     currentLessonId.value = lesson?.id
@@ -220,38 +229,49 @@ fun LessonEditor(
                           style = MaterialTheme.typography.labelMedium)
                     }
               }
+
+              Spacer(modifier = Modifier.height(8.dp))
+
+              // Toggle button for Map Picker
+              Button(onClick = { isMapVisible = !isMapVisible }) {
+                Text(if (isMapVisible) "Hide Map Picker" else "Pick Location on Map")
+              }
+
+              // Display selected location coordinates
+              Text(
+                  "Selected Location: Lat: ${selectedLocation.first}, Lng: ${selectedLocation.second}")
+
+              // Conditional Map Picker display
+              if (isMapVisible) {
+                Box(modifier = Modifier.fillMaxWidth().height(500.dp).padding(top = 16.dp)) {
+                  MapPickerBox(
+                      initialLocation = selectedLocation, onLocationSelected = onLocationSelected)
+                }
+              }
+
+              Spacer(modifier = Modifier.height(8.dp))
+
+              Text(
+                  "Select the subject you want to study",
+                  style = MaterialTheme.typography.titleSmall)
+              SubjectSelector(selectedSubject)
+
+              Spacer(modifier = Modifier.height(8.dp))
+
+              Text(
+                  "Select the possible languages you want the course to take place in",
+                  style = MaterialTheme.typography.titleSmall)
+              LanguageSelector(selectedLanguages)
+
+              Spacer(modifier = Modifier.height(8.dp))
+
+              PriceRangeSlider("Select a price range for your lesson:") { min, max ->
+                minPrice = min.toDouble()
+                maxPrice = max.toDouble()
+              }
+
+              Text("Selected price range: ${minPrice.toInt()}.- to ${maxPrice.toInt()}.-")
             }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Navigation to the map picker screen to select the location of Lesson
-        Button(onClick = { onLocationPicker() }) { Text("Pick Location") }
-
-        // Show selected location if available
-        selectedLocation.let { (latitude, longitude) ->
-          Text("Selected Location: Lat: $latitude, Lng: $longitude")
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text("Select the subject you want to study", style = MaterialTheme.typography.titleSmall)
-        SubjectSelector(selectedSubject)
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            "Select the possible languages you want the course to take place in",
-            style = MaterialTheme.typography.titleSmall)
-        LanguageSelector(selectedLanguages)
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        PriceRangeSlider("Select a price range for your lesson:") { min, max ->
-          minPrice = min.toDouble()
-          maxPrice = max.toDouble()
-        }
-
-        Text("Selected price range: ${minPrice.toInt()}.- to ${maxPrice.toInt()}.-")
       },
       bottomBar = {
         Column {

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -4,6 +4,7 @@ import MapPickerBox
 import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -32,7 +33,6 @@ fun LessonEditor(
     profile: Profile,
     lesson: Lesson?,
     onBack: () -> Unit,
-    onLocationPicker: () -> Unit,
     onConfirm: (Lesson) -> Unit,
     onDelete: ((Lesson) -> Unit)? = null,
 ) {
@@ -49,6 +49,7 @@ fun LessonEditor(
   val currentDateTime = Calendar.getInstance()
   val currentLessonId = remember { mutableStateOf<String?>(null) }
 
+  // Default Location is assigned at EPFL
   var selectedLocation by remember {
     mutableStateOf(lesson?.let { it.latitude to it.longitude } ?: (46.520374 to 6.568339))
   }
@@ -128,6 +129,7 @@ fun LessonEditor(
     if (error != null) {
       Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
     } else {
+      Log.d("LessonEditor", lesson?.id ?: "Lesson is null")
       onConfirm(
           Lesson(
               lesson!!.id,
@@ -234,16 +236,17 @@ fun LessonEditor(
 
               // Toggle button for Map Picker
               Button(onClick = { isMapVisible = !isMapVisible }) {
-                Text(if (isMapVisible) "Hide Map Picker" else "Pick Location on Map")
+                Text(if (isMapVisible) "Hide Map" else "Pick Location on Map")
               }
 
               // Display selected location coordinates
               Text(
-                  "Selected Location: Lat: ${selectedLocation.first}, Lng: ${selectedLocation.second}")
+                  "Click on the Map to select the location",
+              )
 
               // Conditional Map Picker display
               if (isMapVisible) {
-                Box(modifier = Modifier.fillMaxWidth().height(500.dp).padding(top = 16.dp)) {
+                Box(modifier = Modifier.fillMaxWidth().height(400.dp).padding(top = 8.dp)) {
                   MapPickerBox(
                       initialLocation = selectedLocation, onLocationSelected = onLocationSelected)
                 }
@@ -303,6 +306,7 @@ fun validateLessonInput(
     latitude: Double,
     longitude: Double
 ): String? {
+  Log.d("LessonEditor", "Validating lesson input")
   for (entry in
       mapOf(
               "title" to title,
@@ -318,5 +322,6 @@ fun validateLessonInput(
       return "${entry.key} is missing"
     }
   }
+  Log.d("LessonEditor", "Lesson input is valid")
   return null
 }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -48,9 +48,8 @@ fun LessonEditor(
   val currentDateTime = Calendar.getInstance()
   val currentLessonId = remember { mutableStateOf<String?>(null) }
 
-  // Default Location is assigned at EPFL
   var selectedLocation by remember {
-    mutableStateOf(lesson?.let { it.latitude to it.longitude } ?: (46.520374 to 6.568339))
+    mutableStateOf(lesson?.let { it.latitude to it.longitude } ?: (0.0 to 0.0))
   }
   var isMapVisible by remember { mutableStateOf(false) }
   val onLocationSelected: (Pair<Double, Double>) -> Unit = { newLocation ->
@@ -232,19 +231,16 @@ fun LessonEditor(
 
               Spacer(modifier = Modifier.height(8.dp))
 
-              // Toggle button for Map Picker
               Button(onClick = { isMapVisible = !isMapVisible }) {
                 Text(if (isMapVisible) "Hide Map" else "Display the Map")
               }
 
-              // Display selected location coordinates
               Text(
                   "Click on the Map to select the location",
               )
 
-              // Conditional Map Picker display
               if (isMapVisible) {
-                Box(modifier = Modifier.fillMaxWidth().height(400.dp).padding(top = 8.dp)) {
+                Box(modifier = Modifier.fillMaxWidth().height(600.dp).padding(top = 8.dp)) {
                   MapPickerBox(
                       initialLocation = selectedLocation, onLocationSelected = onLocationSelected)
                 }
@@ -304,20 +300,26 @@ fun validateLessonInput(
     latitude: Double,
     longitude: Double
 ): String? {
-  for (entry in
+  val requiredFields =
       mapOf(
-              "title" to title,
-              "description" to description,
-              "subject" to selectedSubject.value.name,
-              "language" to selectedLanguages.joinToString { it.name },
-              "date" to date,
-              "time" to time,
-              "latitude" to latitude.toString(),
-              "longitude" to longitude.toString())
-          .entries) {
-    if (entry.value.isEmpty()) {
-      return "${entry.key} is missing"
+          "title" to title,
+          "description" to description,
+          "subject" to selectedSubject.value.name,
+          "language" to selectedLanguages.joinToString { it.name },
+          "date" to date,
+          "time" to time)
+
+  // Check if any required field is empty
+  for ((field, value) in requiredFields) {
+    if (value.isEmpty()) {
+      return "$field is missing"
     }
   }
-  return null
+
+  // Check if location has been set
+  if (latitude == 0.0 && longitude == 0.0) {
+    return "location is missing"
+  }
+
+  return null // All inputs are valid
 }

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -3,7 +3,6 @@ package com.github.se.project.ui.lesson
 import android.widget.Toast
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
@@ -14,13 +13,11 @@ import com.github.se.project.ui.navigation.Screen
 @Composable
 fun AddLessonScreen(
     navigationActions: NavigationActions,
-    listProfilesViewModel: ListProfilesViewModel =
-        viewModel(factory = ListProfilesViewModel.Factory),
-    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory)
+    listProfilesViewModel: ListProfilesViewModel,
+    lessonViewModel: LessonViewModel,
 ) {
 
   val profile = listProfilesViewModel.currentProfile.collectAsState()
-  val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
 
   val context = LocalContext.current
 
@@ -39,10 +36,8 @@ fun AddLessonScreen(
   LessonEditor(
       mainTitle = "Schedule a new lesson",
       profile = profile.value!!,
-      selectedLocation = selectedLocation,
       lesson = null,
       onBack = { navigationActions.navigateTo(Screen.HOME) },
-      onLocationPicker = { navigationActions.navigateTo(Screen.MAP_LOC_PICKER) },
       onConfirm = onConfirm,
       onDelete = null)
 }

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -45,6 +45,7 @@ fun AddLessonScreen(
   val currentDateTime = Calendar.getInstance()
 
   val profile = listProfilesViewModel.currentProfile.collectAsState()
+    val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
 
   // Context for the Toast messages
   val context = LocalContext.current
@@ -61,6 +62,8 @@ fun AddLessonScreen(
             selectedLanguages,
             selectedDate,
             selectedTime,
+            selectedLocation.first,
+            selectedLocation.second
         )
     if (error != null) {
       Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
@@ -79,6 +82,8 @@ fun AddLessonScreen(
               0.0,
               "${selectedDate}T${selectedTime}:00",
               LessonStatus.REQUESTED,
+              selectedLocation.first,
+              selectedLocation.second
           ),
           onComplete = {
             lessonViewModel.getLessonsForStudent(profile.value!!.uid, onComplete = {})
@@ -88,6 +93,8 @@ fun AddLessonScreen(
       navigationActions.navigateTo(Screen.HOME)
     }
   }
+
+
 
   // Date Picker
   val datePickerDialog =
@@ -216,7 +223,21 @@ fun AddLessonScreen(
 
               Spacer(modifier = Modifier.height(8.dp))
 
-              Text(
+            // Navigation to the map picker screen to select the location of Lesson
+            Button(onClick = {
+                navigationActions.navigateTo(Screen.MAP_LOC_PICKER)
+            }) {
+                Text("Pick Location")
+            }
+
+            // Show selected location if available
+            selectedLocation.let { (latitude, longitude) ->
+                Text("Selected Location: Lat: $latitude, Lng: $longitude")
+            }
+
+          Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
                   "Select the subject you want to study",
                   style = MaterialTheme.typography.titleSmall)
               SubjectSelector(selectedSubject)
@@ -254,7 +275,9 @@ fun validateLessonInput(
     selectedSubject: MutableState<Subject>,
     selectedLanguages: List<Language>,
     date: String,
-    time: String
+    time: String,
+    latitude: Double,
+    longitude: Double
 ): String? {
   for (entry in
       mapOf(
@@ -264,6 +287,8 @@ fun validateLessonInput(
               "language" to selectedLanguages.joinToString { it.name },
               "date" to date,
               "time" to time,
+                "latitude" to latitude.toString(),
+                "longitude" to longitude.toString()
           )
           .entries) {
     if (entry.value.isEmpty()) {

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -45,7 +45,7 @@ fun AddLessonScreen(
   val currentDateTime = Calendar.getInstance()
 
   val profile = listProfilesViewModel.currentProfile.collectAsState()
-    val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
+  val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
 
   // Context for the Toast messages
   val context = LocalContext.current
@@ -63,8 +63,7 @@ fun AddLessonScreen(
             selectedDate,
             selectedTime,
             selectedLocation.first,
-            selectedLocation.second
-        )
+            selectedLocation.second)
     if (error != null) {
       Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
     } else {
@@ -83,8 +82,7 @@ fun AddLessonScreen(
               "${selectedDate}T${selectedTime}:00",
               LessonStatus.REQUESTED,
               selectedLocation.first,
-              selectedLocation.second
-          ),
+              selectedLocation.second),
           onComplete = {
             lessonViewModel.getLessonsForStudent(profile.value!!.uid, onComplete = {})
             Toast.makeText(context, "Lesson added successfully", Toast.LENGTH_SHORT).show()
@@ -93,8 +91,6 @@ fun AddLessonScreen(
       navigationActions.navigateTo(Screen.HOME)
     }
   }
-
-
 
   // Date Picker
   val datePickerDialog =
@@ -223,21 +219,19 @@ fun AddLessonScreen(
 
               Spacer(modifier = Modifier.height(8.dp))
 
-            // Navigation to the map picker screen to select the location of Lesson
-            Button(onClick = {
-                navigationActions.navigateTo(Screen.MAP_LOC_PICKER)
-            }) {
+              // Navigation to the map picker screen to select the location of Lesson
+              Button(onClick = { navigationActions.navigateTo(Screen.MAP_LOC_PICKER) }) {
                 Text("Pick Location")
-            }
+              }
 
-            // Show selected location if available
-            selectedLocation.let { (latitude, longitude) ->
+              // Show selected location if available
+              selectedLocation.let { (latitude, longitude) ->
                 Text("Selected Location: Lat: $latitude, Lng: $longitude")
-            }
+              }
 
-          Spacer(modifier = Modifier.height(8.dp))
+              Spacer(modifier = Modifier.height(8.dp))
 
-            Text(
+              Text(
                   "Select the subject you want to study",
                   style = MaterialTheme.typography.titleSmall)
               SubjectSelector(selectedSubject)
@@ -287,9 +281,8 @@ fun validateLessonInput(
               "language" to selectedLanguages.joinToString { it.name },
               "date" to date,
               "time" to time,
-                "latitude" to latitude.toString(),
-                "longitude" to longitude.toString()
-          )
+              "latitude" to latitude.toString(),
+              "longitude" to longitude.toString())
           .entries) {
     if (entry.value.isEmpty()) {
       return "${entry.key} is missing"

--- a/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
@@ -55,10 +55,8 @@ fun EditRequestedLessonScreen(
   LessonEditor(
       mainTitle = "Edit requested lesson",
       profile = profile.value!!,
-      selectedLocation = selectedLocation,
       lesson = lesson,
       onBack = { navigationActions.navigateTo(Screen.HOME) },
       onConfirm = onConfirm,
-      onDelete = onDelete,
-      onLocationPicker = {})
+      onDelete = onDelete)
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -17,12 +17,21 @@ fun MapPickerBox(
     initialLocation: Pair<Double, Double>,
     onLocationSelected: (Pair<Double, Double>) -> Unit
 ) {
+  val EPFLCoordinates = LatLng(46.520374, 6.568339)
+
   var selectedPosition by remember {
     mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
   }
   val markerState = rememberMarkerState(position = selectedPosition)
+
   val cameraPositionState = rememberCameraPositionState {
-    position = CameraPosition.fromLatLngZoom(selectedPosition, 10f)
+    position =
+        // If no location is selected yet, set the camera position on the EPFL
+        if (selectedPosition.latitude == 0.0 && selectedPosition.longitude == 0.0) {
+          CameraPosition.fromLatLngZoom(EPFLCoordinates, 10f)
+        } else {
+          CameraPosition.fromLatLngZoom(selectedPosition, 10f)
+        }
   }
 
   Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
@@ -33,10 +42,13 @@ fun MapPickerBox(
           selectedPosition = latLng
           markerState.position = selectedPosition
         }) {
-          Marker(
-              state = markerState,
-              title = "Selected Location",
-              snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}")
+          // Display marker only if initialLocation is not (0, 0)
+          if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0) {
+            Marker(
+                state = markerState,
+                title = "Location of the Lesson",
+            )
+          }
         }
 
     Button(

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -4,11 +4,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.github.se.project.model.lesson.LessonViewModel
-import com.github.se.project.ui.navigation.NavigationActions
-import com.github.se.project.ui.navigation.Screen
-import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
@@ -18,53 +13,36 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 
 @Composable
-fun MapPickerScreen(
-    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
-    navigationActions: NavigationActions
+fun MapPickerBox(
+    initialLocation: Pair<Double, Double>,
+    onLocationSelected: (Pair<Double, Double>) -> Unit
 ) {
   var selectedPosition by remember {
-    mutableStateOf(
-        LatLng(
-            lessonViewModel.selectedLocation.value.first,
-            lessonViewModel.selectedLocation.value.second))
+    mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
   }
-
   val markerState = rememberMarkerState(position = selectedPosition)
-
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(selectedPosition, 10f)
   }
 
-  Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp),
-      verticalArrangement = Arrangement.SpaceBetween) {
-        GoogleMap(
-            modifier =
-                Modifier.fillMaxWidth().weight(1f), // Take available space except the button area
-            cameraPositionState = cameraPositionState,
-            onMapClick = { latLng ->
-              selectedPosition = latLng
-              markerState.position = selectedPosition // Update the marker position
-            }) {
-              Marker(
-                  state = markerState,
-                  title = "Selected Location",
-                  snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}",
-                  icon =
-                      BitmapDescriptorFactory.defaultMarker(
-                          BitmapDescriptorFactory.HUE_RED) // Customize the icon
-                  )
-            }
+  Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+    GoogleMap(
+        modifier = Modifier.fillMaxWidth().height(250.dp),
+        cameraPositionState = cameraPositionState,
+        onMapClick = { latLng ->
+          selectedPosition = latLng
+          markerState.position = selectedPosition
+        }) {
+          Marker(
+              state = markerState,
+              title = "Selected Location",
+              snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}")
+        }
 
-        Button(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
-            onClick = {
-              lessonViewModel.updateSelectedLocation(
-                  selectedPosition.latitude to selectedPosition.longitude)
-
-              navigationActions.navigateTo(Screen.ADD_LESSON)
-            }) {
-              Text("Confirm Location")
-            }
-      }
+    Button(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+        onClick = { onLocationSelected(selectedPosition.latitude to selectedPosition.longitude) }) {
+          Text("Confirm Location")
+        }
+  }
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -2,7 +2,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -23,60 +22,49 @@ fun MapPickerScreen(
     lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
     navigationActions: NavigationActions
 ) {
-    var selectedPosition by remember {
-        mutableStateOf(
-            LatLng(
-                lessonViewModel.selectedLocation.value.first,
-                lessonViewModel.selectedLocation.value.second
-            )
-        )
-    }
+  var selectedPosition by remember {
+    mutableStateOf(
+        LatLng(
+            lessonViewModel.selectedLocation.value.first,
+            lessonViewModel.selectedLocation.value.second))
+  }
 
-    val markerState = rememberMarkerState(position = selectedPosition)
+  val markerState = rememberMarkerState(position = selectedPosition)
 
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(selectedPosition, 10f)
-    }
+  val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(selectedPosition, 10f)
+  }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.SpaceBetween
-    ) {
-
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp),
+      verticalArrangement = Arrangement.SpaceBetween) {
         GoogleMap(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f), // Take available space except the button area
+            modifier =
+                Modifier.fillMaxWidth().weight(1f), // Take available space except the button area
             cameraPositionState = cameraPositionState,
             onMapClick = { latLng ->
-                selectedPosition = latLng
-                markerState.position = selectedPosition // Update the marker position
+              selectedPosition = latLng
+              markerState.position = selectedPosition // Update the marker position
+            }) {
+              Marker(
+                  state = markerState,
+                  title = "Selected Location",
+                  snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}",
+                  icon =
+                      BitmapDescriptorFactory.defaultMarker(
+                          BitmapDescriptorFactory.HUE_RED) // Customize the icon
+                  )
             }
-        ) {
-
-            Marker(
-                state = markerState,
-                title = "Selected Location",
-                snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}",
-                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED) // Customize the icon
-            )
-        }
-
 
         Button(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
             onClick = {
+              lessonViewModel.updateSelectedLocation(
+                  selectedPosition.latitude to selectedPosition.longitude)
 
-                lessonViewModel.updateSelectedLocation(selectedPosition.latitude to selectedPosition.longitude)
-
-                navigationActions.navigateTo(Screen.ADD_LESSON)
+              navigationActions.navigateTo(Screen.ADD_LESSON)
+            }) {
+              Text("Confirm Location")
             }
-        ) {
-            Text("Confirm Location")
-        }
-    }
+      }
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -1,0 +1,82 @@
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Screen
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
+
+@Composable
+fun MapPickerScreen(
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
+    navigationActions: NavigationActions
+) {
+    var selectedPosition by remember {
+        mutableStateOf(
+            LatLng(
+                lessonViewModel.selectedLocation.value.first,
+                lessonViewModel.selectedLocation.value.second
+            )
+        )
+    }
+
+    val markerState = rememberMarkerState(position = selectedPosition)
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(selectedPosition, 10f)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+
+        GoogleMap(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f), // Take available space except the button area
+            cameraPositionState = cameraPositionState,
+            onMapClick = { latLng ->
+                selectedPosition = latLng
+                markerState.position = selectedPosition // Update the marker position
+            }
+        ) {
+
+            Marker(
+                state = markerState,
+                title = "Selected Location",
+                snippet = "Lat: ${selectedPosition.latitude}, Lng: ${selectedPosition.longitude}",
+                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED) // Customize the icon
+            )
+        }
+
+
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            onClick = {
+
+                lessonViewModel.updateSelectedLocation(selectedPosition.latitude to selectedPosition.longitude)
+
+                navigationActions.navigateTo(Screen.ADD_LESSON)
+            }
+        ) {
+            Text("Confirm Location")
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -1,9 +1,12 @@
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
@@ -34,9 +37,26 @@ fun MapPickerBox(
         }
   }
 
-  Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+  Column (modifier = Modifier.fillMaxWidth().padding(16.dp)) {
     GoogleMap(
-        modifier = Modifier.fillMaxWidth().height(400.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(400.dp)
+            //Pass the scrolling and zooming gestures to the map
+            .pointerInput(Unit) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    // Update camera zoom
+                    cameraPositionState.move(
+                        CameraUpdateFactory.zoomBy(zoom - 1) // zoom factor correction
+                    )
+
+                    // Update camera position by panning
+                    cameraPositionState.move(
+                        CameraUpdateFactory.scrollBy(-pan.x, -pan.y)
+                    )
+                }
+            },
+
         cameraPositionState = cameraPositionState,
         onMapClick = { latLng ->
           selectedPosition = latLng
@@ -50,6 +70,8 @@ fun MapPickerBox(
             )
           }
         }
+
+    Spacer(modifier = Modifier.height(8.dp))
 
     Button(
         modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -27,7 +27,7 @@ fun MapPickerBox(
 
   Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
     GoogleMap(
-        modifier = Modifier.fillMaxWidth().height(250.dp),
+        modifier = Modifier.fillMaxWidth().height(400.dp),
         cameraPositionState = cameraPositionState,
         onMapClick = { latLng ->
           selectedPosition = latLng
@@ -40,7 +40,7 @@ fun MapPickerBox(
         }
 
     Button(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
         onClick = { onLocationSelected(selectedPosition.latitude to selectedPosition.longitude) }) {
           Text("Confirm Location")
         }

--- a/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
@@ -29,6 +29,7 @@ object Screen {
   const val ADD_LESSON = "Add Lesson Screen"
   const val CREATE_TUTOR_SCHEDULE = "Create tutor calendar Screen"
   const val SEARCH = "Search Screen" // Find tutor / find student screen
+  const val MAP_LOC_PICKER = "Map Screen"
 }
 
 // Data class for top-level destinations

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
@@ -44,7 +44,9 @@ class LessonRepositoryFirestoreTest {
           minPrice = 20.0,
           maxPrice = 40.0,
           timeSlot = "2024-10-10T10:00:00",
-          status = LessonStatus.PENDING)
+          status = LessonStatus.PENDING,
+            latitude = 0.0,
+            longitude = 0.0)
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonRepositoryFirestoreTest.kt
@@ -45,8 +45,8 @@ class LessonRepositoryFirestoreTest {
           maxPrice = 40.0,
           timeSlot = "2024-10-10T10:00:00",
           status = LessonStatus.PENDING,
-            latitude = 0.0,
-            longitude = 0.0)
+          latitude = 0.0,
+          longitude = 0.0)
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
@@ -31,8 +31,8 @@ class LessonViewModelTest {
           maxPrice = 40.0,
           timeSlot = "2024-10-10T10:00:00",
           status = LessonStatus.PENDING,
-            latitude = 0.0,
-            longitude = 0.0)
+          latitude = 0.0,
+          longitude = 0.0)
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
@@ -30,7 +30,9 @@ class LessonViewModelTest {
           minPrice = 20.0,
           maxPrice = 40.0,
           timeSlot = "2024-10-10T10:00:00",
-          status = LessonStatus.PENDING)
+          status = LessonStatus.PENDING,
+            latitude = 0.0,
+            longitude = 0.0)
 
   @Before
   fun setUp() {


### PR DESCRIPTION
## Description:

This PR fix #80 a scrolling conflict between the outer Column and the GoogleMap component within the MapPickerBox. Previously, scrolling on the map was inadvertently intercepted by the Column, causing the entire screen to scroll instead of allowing interaction directly with the map. This fix ensures that touch gestures on the map are handled within the MapPickerBox, allowing users to scroll and zoom on the map without affecting the Column's scrolling.

Further details on the screen can be found on #79 

## Changes Made:

Added pointerInput to the GoogleMap modifier within MapPickerBox to handle gestures specifically on the map component.
Used detectTransformGestures to intercept panning and zooming gestures on the map, preventing these gestures from propagating to the Column.
Reversed panning direction within MapPickerBox to provide a natural map interaction experience.

## Design suggestions

We could use a Dialogue instead of a Box to easily transfer these interactions between components