### PR TITLE
Feat/tutor match

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/AddLessonTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.*
 import com.github.se.project.ui.components.PriceRangeSlider
@@ -39,7 +40,10 @@ class AddLessonTest {
       mock(ListProfilesViewModel::class.java).apply {
         `when`(currentProfile).thenReturn(MutableStateFlow<Profile?>(profile))
       }
-  private val mockLessons = mock(LessonViewModel::class.java)
+  private val mockLessons =
+      mock(LessonViewModel::class.java).apply {
+        `when`(selectedLesson).thenReturn(MutableStateFlow<Lesson?>(null))
+      }
 
   @Test
   fun AddLessonIsProperlyDisplayed() {

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -48,7 +48,7 @@ class LessonsRequestedScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T10:00:00",
-              status = LessonStatus.REQUESTED,
+              status = LessonStatus.PENDING,
               latitude = 0.0,
               longitude = 0.0),
           Lesson(
@@ -62,7 +62,7 @@ class LessonsRequestedScreenTest {
               minPrice = 20.0,
               maxPrice = 40.0,
               timeSlot = "2024-10-10T11:00:00",
-              status = LessonStatus.REQUESTED,
+              status = LessonStatus.PENDING,
               latitude = 0.0,
               longitude = 0.0))
   private val requestedLessonsFlow = MutableStateFlow(mockLessons)
@@ -87,7 +87,7 @@ class LessonsRequestedScreenTest {
         }
 
     doReturn(requestedLessonsFlow).`when`(lessonViewModel).requestedLessons
-    doNothing().`when`(lessonRepository).getAllRequestedLessons(any(), any())
+    doNothing().`when`(lessonRepository).getAllPendingLessons(any(), any())
 
     doNothing().`when`(profilesRepository).getProfiles(any(), any())
   }

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/RequestedLessonsTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.project.ui.lesson
 
-import RequestedLessonsScreen
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.project.model.lesson.Lesson

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.github.se.project
 
-import RequestedLessonsScreen
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -23,7 +22,9 @@ import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.ui.authentification.SignInScreen
 import com.github.se.project.ui.lesson.AddLessonScreen
 import com.github.se.project.ui.lesson.EditRequestedLessonScreen
+import com.github.se.project.ui.lesson.RequestedLessonsScreen
 import com.github.se.project.ui.lesson.TutorLessonResponseScreen
+import com.github.se.project.ui.lesson.TutorMatchingScreen
 import com.github.se.project.ui.navigation.NavigationActions
 import com.github.se.project.ui.navigation.Route
 import com.github.se.project.ui.navigation.Screen
@@ -150,6 +151,9 @@ fun PocketTutorApp() {
       }
       composable(Screen.ADD_LESSON) {
         AddLessonScreen(navigationActions, listProfilesViewModel, lessonViewModel)
+      }
+      composable(Screen.TUTOR_MATCH) {
+        TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
       composable(Screen.EDIT_PROFILE) { EditProfile(navigationActions, listProfilesViewModel) }
       composable(Screen.EDIT_SCHEDULE) {

--- a/app/src/main/java/com/github/se/project/MainActivity.kt
+++ b/app/src/main/java/com/github/se/project/MainActivity.kt
@@ -10,12 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import com.github.se.project.model.authentification.AuthenticationViewModel
 import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
@@ -139,6 +137,16 @@ fun PocketTutorApp() {
       composable(Screen.HOME) {
         HomeScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
+      composable(Screen.EDIT_PROFILE) { EditProfile(navigationActions, listProfilesViewModel) }
+      composable(Screen.EDIT_SCHEDULE) {
+        EditTutorSchedule(navigationActions, listProfilesViewModel)
+      }
+      composable(Screen.EDIT_REQUESTED_LESSON) {
+        EditRequestedLessonScreen(navigationActions, listProfilesViewModel, lessonViewModel)
+      }
+      composable(Screen.TUTOR_LESSON_RESPONSE) {
+        TutorLessonResponseScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+      }
     }
 
     navigation(
@@ -154,17 +162,15 @@ fun PocketTutorApp() {
       composable(Screen.TUTOR_MATCH) {
         TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
       }
-      composable(Screen.EDIT_PROFILE) { EditProfile(navigationActions, listProfilesViewModel) }
-      composable(Screen.EDIT_SCHEDULE) {
-        EditTutorSchedule(navigationActions, listProfilesViewModel)
-      }
-      composable(
-          Screen.EDIT_REQUESTED_LESSON + "/{Lesson ID}",
-          arguments = listOf(navArgument("Lesson ID") { type = NavType.StringType })) { entry ->
-            val lessonId = entry.arguments?.getString("Lesson ID")!!
-            EditRequestedLessonScreen(
-                lessonId, navigationActions, listProfilesViewModel, lessonViewModel)
-          }
+      //      composable(Screen.EDIT_PROFILE) { EditProfile(navigationActions,
+      // listProfilesViewModel) }
+      //      composable(Screen.EDIT_SCHEDULE) {
+      //        EditTutorSchedule(navigationActions, listProfilesViewModel)
+      //      }
+      //      composable(Screen.EDIT_REQUESTED_LESSON) {
+      //        EditRequestedLessonScreen(
+      //          navigationActions, listProfilesViewModel, lessonViewModel)
+      //      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepository.kt
@@ -22,7 +22,7 @@ interface LessonRepository {
   )
 
   // Method to retrieve all requested lessons of the database
-  fun getAllRequestedLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit)
+  fun getAllPendingLessons(onSuccess: (List<Lesson>) -> Unit, onFailure: (Exception) -> Unit)
 
   // Method to add a new lesson
   fun addLesson(lesson: Lesson, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonRepositoryFirestore.kt
@@ -27,12 +27,12 @@ class LessonRepositoryFirestore(private val db: FirebaseFirestore) : LessonRepos
     }
   }
 
-  override fun getAllRequestedLessons(
+  override fun getAllPendingLessons(
       onSuccess: (List<Lesson>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     db.collection(collectionPath)
-        .whereEqualTo("status", LessonStatus.STUDENT_REQUESTED.name)
+        .whereEqualTo("status", LessonStatus.PENDING.name)
         .get()
         .addOnCompleteListener { task ->
           if (task.isSuccessful) {

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
@@ -2,8 +2,6 @@ package com.github.se.project.model.lesson
 
 // Enum class to define lesson status
 enum class LessonStatus {
-  REQUESTED, // Lesson has been requested => TODO: remove this (replaced by STUDENT_REQUESTED and
-  // TUTOR_REQUESTED)
   STUDENT_REQUESTED, // Lesson has been requested by student => need to be confirmed by the tutor
   TUTOR_REQUESTED, // Lesson has been requested by tutor => need to be confirmed by the student
   PENDING, // Lesson is pending => need to find a tutor

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -122,6 +122,11 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
     _selectedLesson.value = lesson
   }
 
+  /** Un-Select the selected lesson. */
+  fun unselectLesson() {
+    _selectedLesson.value = null
+  }
+
   /**
    * Fetches all lessons for a specific tutor.
    *
@@ -166,7 +171,7 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
    * @param onComplete Callback to execute when the operation completes.
    */
   fun getAllRequestedLessons(onComplete: () -> Unit = {}) {
-    repository.getAllRequestedLessons(
+    repository.getAllPendingLessons(
         onSuccess = { fetchedLessons ->
           requestedLessons_.value = fetchedLessons
           onComplete()

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
@@ -66,7 +66,8 @@ fun DisplayLessons(
                         lesson.status == LessonStatus.COMPLETED ->
                             MaterialTheme.colorScheme.secondaryContainer
                         lesson.status == LessonStatus.PENDING ||
-                            lesson.status == LessonStatus.REQUESTED ->
+                            lesson.status == LessonStatus.STUDENT_REQUESTED ||
+                            lesson.status == LessonStatus.TUTOR_REQUESTED ->
                             if (isSystemInDarkTheme()) MaterialTheme.colorScheme.primaryContainer
                             else Color(0xFFFEDF89)
                         else -> MaterialTheme.colorScheme.surfaceContainerHigh

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
@@ -37,12 +37,12 @@ fun DisplayTutors(
                 modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("tutorContent_$index"),
                 verticalArrangement = Arrangement.spacedBy(8.dp)) {
                   Text(
-                      text = tutor.firstName + tutor.lastName,
+                      text = tutor.firstName + " " + tutor.lastName,
                       style = MaterialTheme.typography.titleMedium,
                       modifier = Modifier.testTag("tutorName_$index"))
 
                   Text(
-                      text = tutor.section.toString() + tutor.academicLevel.toString(),
+                      text = tutor.section.toString() + " " + tutor.academicLevel.toString(),
                       style = MaterialTheme.typography.bodyLarge,
                       modifier = Modifier.testTag("tutorLevel_$index"))
                 }

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
@@ -1,0 +1,52 @@
+package com.github.se.project.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.se.project.model.profile.Profile
+
+@Composable
+fun DisplayTutors(
+    modifier: Modifier = Modifier,
+    tutors: List<Profile>,
+    onCardClick: (Profile) -> Unit = {}
+) {
+  LazyColumn(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    itemsIndexed(tutors) { index, tutor ->
+      Card(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .padding(vertical = 2.dp)
+                  .testTag("tutorCard_$index")
+                  .clickable { onCardClick(tutor) },
+          colors =
+              CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceBright)) {
+            Column(
+                modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("tutorContent_$index"),
+                verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                  Text(
+                      text = tutor.firstName + tutor.lastName,
+                      style = MaterialTheme.typography.titleMedium,
+                      modifier = Modifier.testTag("tutorName_$index"))
+
+                  Text(
+                      text = tutor.section.toString() + tutor.academicLevel.toString(),
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("tutorLevel_$index"))
+                }
+          }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -5,13 +5,36 @@ import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.widget.Toast
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -140,7 +163,7 @@ fun LessonEditor(
               maxPrice,
               0.0,
               "${selectedDate}T${selectedTime}:00",
-              LessonStatus.STUDENT_REQUESTED,
+              LessonStatus.PENDING,
               selectedLocation.first,
               selectedLocation.second))
     }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -173,7 +173,7 @@ fun LessonEditor(
               maxPrice,
               0.0,
               "${selectedDate}T${selectedTime}:00",
-              LessonStatus.PENDING,
+              lesson?.status ?: LessonStatus.PENDING,
               selectedLocation.first,
               selectedLocation.second))
     }

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -1,8 +1,7 @@
 package com.github.se.project.ui.lesson
 
-import android.widget.Toast
-import androidx.compose.runtime.*
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
@@ -19,16 +18,12 @@ fun AddLessonScreen(
 
   val profile = listProfilesViewModel.currentProfile.collectAsState()
 
-  val context = LocalContext.current
+  val currentLesson = lessonViewModel.selectedLesson.collectAsState().value
 
   val onConfirm = { lesson: Lesson ->
-    lesson.id = lessonViewModel.getNewUid()
-    lessonViewModel.addLesson(
-        lesson,
-        onComplete = {
-          lessonViewModel.getLessonsForStudent(profile.value!!.uid, onComplete = {})
-          Toast.makeText(context, "Lesson added successfully", Toast.LENGTH_SHORT).show()
-        })
+    if (currentLesson == null) {
+      lesson.id = lessonViewModel.getNewUid()
+    }
     lessonViewModel.selectLesson(lesson)
     navigationActions.navigateTo(Screen.TUTOR_MATCH)
   }
@@ -36,7 +31,7 @@ fun AddLessonScreen(
   LessonEditor(
       mainTitle = "Schedule a new lesson",
       profile = profile.value!!,
-      lesson = null,
+      lesson = currentLesson,
       onBack = { navigationActions.navigateTo(Screen.HOME) },
       onConfirm = onConfirm,
       onDelete = null)

--- a/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/AddLesson.kt
@@ -29,8 +29,8 @@ fun AddLessonScreen(
           lessonViewModel.getLessonsForStudent(profile.value!!.uid, onComplete = {})
           Toast.makeText(context, "Lesson added successfully", Toast.LENGTH_SHORT).show()
         })
-
-    navigationActions.navigateTo(Screen.HOME)
+    lessonViewModel.selectLesson(lesson)
+    navigationActions.navigateTo(Screen.TUTOR_MATCH)
   }
 
   LessonEditor(

--- a/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
@@ -1,6 +1,7 @@
 package com.github.se.project.ui.lesson
 
 import android.widget.Toast
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import com.github.se.project.model.lesson.Lesson
@@ -12,7 +13,6 @@ import com.github.se.project.ui.navigation.Screen
 
 @Composable
 fun EditRequestedLessonScreen(
-    lessonId: String,
     navigationActions: NavigationActions,
     listProfilesViewModel: ListProfilesViewModel,
     lessonViewModel: LessonViewModel,
@@ -21,12 +21,9 @@ fun EditRequestedLessonScreen(
   val profile = listProfilesViewModel.currentProfile.collectAsState()
   val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
 
-  val lessons = lessonViewModel.currentUserLessons.collectAsState()
-
-  val lesson = lessons.value.find { it.id == lessonId }
-  if (lesson == null) {
-    return
-  }
+  val currentLesson =
+      lessonViewModel.selectedLesson.collectAsState().value
+          ?: return Text("No lesson selected. Should not happen")
 
   val context = LocalContext.current
 
@@ -55,7 +52,7 @@ fun EditRequestedLessonScreen(
   LessonEditor(
       mainTitle = "Edit requested lesson",
       profile = profile.value!!,
-      lesson = lesson,
+      lesson = currentLesson,
       onBack = { navigationActions.navigateTo(Screen.HOME) },
       onConfirm = onConfirm,
       onDelete = onDelete)

--- a/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/RequestedLessons.kt
@@ -1,3 +1,5 @@
+package com.github.se.project.ui.lesson
+
 import android.app.DatePickerDialog
 import android.util.Log
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -145,7 +145,10 @@ fun TutorLessonResponseScreen(
                           lesson.copy(
                               tutorUid = currentProfile.uid,
                               price = currentProfile.price.toDouble(),
-                              status = if (lesson.status == LessonStatus.STUDENT_REQUESTED) LessonStatus.CONFIRMED else LessonStatus.TUTOR_REQUESTED,
+                              status =
+                                  if (lesson.status == LessonStatus.STUDENT_REQUESTED)
+                                      LessonStatus.CONFIRMED
+                                  else LessonStatus.TUTOR_REQUESTED,
                           ),
                           onComplete = {
                             lessonViewModel.getLessonsForTutor(currentProfile.uid)

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -145,7 +145,7 @@ fun TutorLessonResponseScreen(
                           lesson.copy(
                               tutorUid = currentProfile.uid,
                               price = currentProfile.price.toDouble(),
-                              status = LessonStatus.TUTOR_REQUESTED,
+                              status = if (lesson.status == LessonStatus.STUDENT_REQUESTED) LessonStatus.CONFIRMED else LessonStatus.TUTOR_REQUESTED,
                           ),
                           onComplete = {
                             lessonViewModel.getLessonsForTutor(currentProfile.uid)

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorLessonResponse.kt
@@ -43,6 +43,8 @@ fun TutorLessonResponseScreen(
   var showConfirmDialog by remember { mutableStateOf(false) }
   val context = LocalContext.current
 
+  var showDeclineDialog by remember { mutableStateOf(false) }
+
   Scaffold(
       containerColor = MaterialTheme.colorScheme.background,
       topBar = {
@@ -57,10 +59,17 @@ fun TutorLessonResponseScreen(
                   }
             },
             title = {
-              Text(
-                  text = "Respond to Request",
-                  style = MaterialTheme.typography.titleLarge,
-                  modifier = Modifier.testTag("TutorLessonResponseTitle"))
+              if (lesson.status == LessonStatus.STUDENT_REQUESTED) {
+                Text(
+                    text = "Confirm the Lesson",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.testTag("confirmLessonTitle"))
+              } else {
+                Text(
+                    text = "Respond to Request",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.testTag("requestPendingLessonTitle"))
+              }
             })
       }) { paddingValues ->
         Column(
@@ -103,6 +112,20 @@ fun TutorLessonResponseScreen(
                       Spacer(modifier = Modifier.width(8.dp))
                       Text("Offer to Teach (${currentProfile.price}.-/hour)")
                     }
+
+                if (lesson.status == LessonStatus.STUDENT_REQUESTED) {
+                  Button(
+                      onClick = { showDeclineDialog = true },
+                      modifier =
+                          Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("cancelButton")) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Dismiss the Lesson")
+                      }
+                }
               }
             }
 
@@ -127,6 +150,36 @@ fun TutorLessonResponseScreen(
                           onComplete = {
                             lessonViewModel.getLessonsForTutor(currentProfile.uid)
                             Toast.makeText(context, "Offer sent successfully!", Toast.LENGTH_SHORT)
+                                .show()
+                            navigationActions.navigateTo(Screen.HOME)
+                          })
+                    }) {
+                      Text("Confirm")
+                    }
+              },
+              dismissButton = {
+                TextButton(onClick = { showConfirmDialog = false }) { Text("Cancel") }
+              })
+        }
+
+        // Decline Dialog
+        if (showDeclineDialog) {
+          AlertDialog(
+              onDismissRequest = { showDeclineDialog = false },
+              title = { Text("Dismiss the Lesson") },
+              text = { Text("Are you sure you want to dismiss this lesson?") },
+              confirmButton = {
+                Button(
+                    onClick = {
+                      lessonViewModel.updateLesson(
+                          lesson.copy(
+                              tutorUid = "",
+                              status = LessonStatus.PENDING,
+                          ),
+                          onComplete = {
+                            lessonViewModel.getLessonsForTutor(currentProfile.uid)
+                            Toast.makeText(
+                                    context, "Lesson dismiss successfully.", Toast.LENGTH_SHORT)
                                 .show()
                             navigationActions.navigateTo(Screen.HOME)
                           })

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
@@ -1,12 +1,29 @@
 package com.github.se.project.ui.lesson
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Menu
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -64,16 +81,6 @@ fun TutorMatchingScreen(
             AcademicLevel.BA1))
   }
 
-  //    val onBackClick = @Composable {
-  //        LessonEditor(
-  //            mainTitle = "Edit requested lesson",
-  //            profile = profile.value!!,
-  //            lesson = currentLesson,
-  //            onBack = { navigationActions.navigateTo(Screen.HOME) },
-  //            onConfirm = onConfirm,
-  //            onDelete = onDelete)
-  //        navigationActions.navigateTo(Screen.HOME)
-  //    }
   Scaffold(
       topBar = {
         Row(
@@ -101,7 +108,15 @@ fun TutorMatchingScreen(
       bottomBar = {
         Button(
             modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("confirmButton"),
-            onClick = { navigationActions.navigateTo(Screen.HOME) }) {
+            onClick = {
+              lessonViewModel.addLesson(
+                  currentLesson,
+                  onComplete = {
+                    lessonViewModel.getLessonsForStudent(currentProfile.uid)
+                    Toast.makeText(context, "Lesson sent successfully!", Toast.LENGTH_SHORT).show()
+                  })
+              navigationActions.navigateTo(Screen.HOME)
+            }) {
               Text(
                   "Ask other tutor for your lesson",
                   modifier = Modifier.testTag("confirmButtonText"))
@@ -143,11 +158,11 @@ fun TutorMatchingScreen(
               confirmButton = {
                 Button(
                     onClick = {
-                      lessonViewModel.updateLesson(
+                      lessonViewModel.addLesson(
                           currentLesson.copy(
                               tutorUid = chosenTutor.uid,
                               price = chosenTutor.price.toDouble(),
-                              status = LessonStatus.STUDENT_REQUESTED,
+                              status = LessonStatus.STUDENT_REQUESTED, // TODO: update state
                           ),
                           onComplete = {
                             lessonViewModel.getLessonsForStudent(currentProfile.uid)

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
@@ -65,6 +65,7 @@ fun TutorMatchingScreen(
         allProfiles.filter { profile -> // TODO: think of the filtering
           profile.role == Role.TUTOR &&
               profile.subjects.contains(currentLesson.subject) &&
+              profile.price <= currentLesson.maxPrice &&
               isTutorAvailable(profile.schedule, currentLesson.timeSlot)
         }
       } else {

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
@@ -1,0 +1,172 @@
+package com.github.se.project.ui.lesson
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.AcademicLevel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.model.profile.Profile
+import com.github.se.project.model.profile.Role
+import com.github.se.project.model.profile.Section
+import com.github.se.project.ui.components.DisplayTutors
+import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Screen
+
+@Composable
+fun TutorMatchingScreen(
+    listProfilesViewModel: ListProfilesViewModel =
+        viewModel(factory = ListProfilesViewModel.Factory),
+    lessonViewModel: LessonViewModel = viewModel(factory = LessonViewModel.Factory),
+    navigationActions: NavigationActions
+) {
+  val currentProfile =
+      listProfilesViewModel.currentProfile.collectAsState().value
+          ?: return Text("No profile selected. Should not happen.")
+
+  val currentLesson =
+      lessonViewModel.selectedLesson.collectAsState().value
+          ?: return Text("No lesson selected. Should not happen.")
+
+  val allProfiles by
+      listProfilesViewModel.profiles.collectAsState() // TODO: add field to get only tutor profiles
+
+  val filteredTutor =
+      allProfiles.filter { profile -> // TODO: think of the filtering
+        profile.role == Role.TUTOR &&
+            profile.subjects.contains(currentLesson.subject) &&
+            isTutorAvailable(profile.schedule, currentLesson.timeSlot)
+      }
+
+  var showConfirmDialog by remember { mutableStateOf(false) }
+  val context = LocalContext.current
+  var chosenTutor by remember {
+    mutableStateOf(
+        Profile(
+            "ERROR",
+            "ERROR",
+            "ERROR",
+            "ERROR",
+            "000000000",
+            Role.TUTOR,
+            Section.IN,
+            AcademicLevel.BA1))
+  }
+
+  //    val onBackClick = @Composable {
+  //        LessonEditor(
+  //            mainTitle = "Edit requested lesson",
+  //            profile = profile.value!!,
+  //            lesson = currentLesson,
+  //            onBack = { navigationActions.navigateTo(Screen.HOME) },
+  //            onConfirm = onConfirm,
+  //            onDelete = onDelete)
+  //        navigationActions.navigateTo(Screen.HOME)
+  //    }
+  Scaffold(
+      topBar = {
+        Row(
+            modifier = Modifier.testTag("topBar").fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              IconButton(onClick = { navigationActions.goBack() }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back arrow",
+                    modifier = Modifier.size(32.dp).testTag("backButton"))
+              }
+
+              Text(
+                  text = "Available Tutors",
+                  style = MaterialTheme.typography.headlineMedium,
+                  modifier = Modifier.testTag("AvailableTutorsTitle"))
+
+              IconButton(
+                  onClick = { /* TODO: Additional filter options */},
+                  modifier = Modifier.testTag("filterButton")) {
+                    Icon(imageVector = Icons.Outlined.Menu, contentDescription = "Filter")
+                  }
+            }
+      },
+      bottomBar = {
+        Button(
+            modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("confirmButton"),
+            onClick = { navigationActions.navigateTo(Screen.HOME) }) {
+              Text(
+                  "Ask other tutor for your lesson",
+                  modifier = Modifier.testTag("confirmButtonText"))
+            }
+      }) { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(innerPadding),
+        ) {
+          if (filteredTutor.isEmpty()) {
+            Text(
+                text =
+                    "No tutor available for your lesson: go back to change your lesson or click on the button to wait for a tutor to choose your lesson.",
+                modifier = Modifier.align(Alignment.Center).testTag("noTutorMessage"))
+          } else {
+            DisplayTutors(
+                modifier =
+                    Modifier.padding(horizontal = 12.dp, vertical = 12.dp)
+                        .fillMaxWidth()
+                        .testTag("tutorsList"),
+                tutors = filteredTutor,
+                onCardClick = { tutor ->
+                  // TODO: replace this by a screen to see the different rankings
+
+                  chosenTutor = tutor
+                  showConfirmDialog = true
+                })
+          }
+        }
+
+        // Confirmation Dialog
+        if (showConfirmDialog) {
+          AlertDialog(
+              onDismissRequest = { showConfirmDialog = false },
+              title = { Text("Confirm Your Choice") },
+              text = {
+                Text(
+                    "Would you like to choose this tutor for your lesson and pay a price of ${chosenTutor.price}.-/hour?")
+              },
+              confirmButton = {
+                Button(
+                    onClick = {
+                      lessonViewModel.updateLesson(
+                          currentLesson.copy(
+                              tutorUid = chosenTutor.uid,
+                              price = chosenTutor.price.toDouble(),
+                              status = LessonStatus.STUDENT_REQUESTED,
+                          ),
+                          onComplete = {
+                            lessonViewModel.getLessonsForStudent(currentProfile.uid)
+                            Toast.makeText(context, "Lesson sent successfully!", Toast.LENGTH_SHORT)
+                                .show()
+                            navigationActions.navigateTo(Screen.HOME)
+                          })
+                    }) {
+                      Text("Confirm")
+                    }
+              },
+              dismissButton = {
+                TextButton(onClick = { showConfirmDialog = false }) { Text("Cancel") }
+              })
+        }
+      }
+}
+
+// TODO: fill this function
+fun isTutorAvailable(tutorSchedule: List<List<Int>>, timeSlot: String): Boolean {
+  return true
+}

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
@@ -2,22 +2,22 @@ package com.github.se.project.ui.lesson
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -41,6 +41,7 @@ import com.github.se.project.ui.components.DisplayTutors
 import com.github.se.project.ui.navigation.NavigationActions
 import com.github.se.project.ui.navigation.Screen
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TutorMatchingScreen(
     listProfilesViewModel: ListProfilesViewModel =
@@ -92,27 +93,28 @@ fun TutorMatchingScreen(
 
   Scaffold(
       topBar = {
-        Row(
-            modifier = Modifier.testTag("topBar").fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically) {
+        TopAppBar(
+            navigationIcon = {
               IconButton(onClick = { navigationActions.goBack() }) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Back arrow",
-                    modifier = Modifier.size(32.dp).testTag("backButton"))
+                    modifier = Modifier.testTag("backButton"))
               }
-
+            },
+            title = {
               Text(
                   text = "Available Tutors",
-                  style = MaterialTheme.typography.headlineMedium,
+                  style = MaterialTheme.typography.titleLarge,
                   modifier = Modifier.testTag("AvailableTutorsTitle"))
-
+            },
+            actions = {
               IconButton(
                   onClick = { /* TODO: Additional filter options */},
                   modifier = Modifier.testTag("filterButton")) {
                     Icon(imageVector = Icons.Outlined.Menu, contentDescription = "Filter")
                   }
-            }
+            })
       },
       bottomBar = {
         if (currentLesson.status == LessonStatus.PENDING) {
@@ -174,7 +176,10 @@ fun TutorMatchingScreen(
                           currentLesson.copy(
                               tutorUid = chosenTutor.uid,
                               price = chosenTutor.price.toDouble(),
-                              status = LessonStatus.STUDENT_REQUESTED, // TODO: update state
+                              status =
+                                  if (currentLesson.status == LessonStatus.TUTOR_REQUESTED)
+                                      LessonStatus.CONFIRMED
+                                  else LessonStatus.STUDENT_REQUESTED, // TODO: update state
                           ),
                           onComplete = {
                             lessonViewModel.getLessonsForStudent(currentProfile.uid)

--- a/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/project/ui/navigation/NavigationActions.kt
@@ -28,6 +28,7 @@ object Screen {
   const val CREATE_TUTOR_PROFILE = "Tutor information creation Screen"
   const val CALENDAR = "Calendar Screen"
   const val ADD_LESSON = "Add Lesson Screen"
+  const val TUTOR_MATCH = "Tutor matching Screen"
   const val EDIT_REQUESTED_LESSON = "Edit Requested Lesson"
   const val EDIT_SCHEDULED_LESSON = "Edit Scheduled Lesson"
   const val CREATE_TUTOR_SCHEDULE = "Create tutor calendar Screen"

--- a/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
@@ -54,7 +54,16 @@ fun HomeScreen(
 
   val onLessonClick = { lesson: Lesson ->
     if (currentProfile?.role == Role.STUDENT) {
-      navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON + "/${lesson.id}")
+      if (lesson.status == LessonStatus.STUDENT_REQUESTED ||
+          lesson.status == LessonStatus.PENDING) {
+        lessonViewModel.selectLesson(lesson)
+        navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
+      }
+    } else {
+      if (lesson.status == LessonStatus.STUDENT_REQUESTED) {
+        lessonViewModel.selectLesson(lesson)
+        navigationActions.navigateTo(Screen.TUTOR_LESSON_RESPONSE)
+      }
     }
   }
 
@@ -78,7 +87,12 @@ fun HomeScreen(
       },
       bottomBar = {
         BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            onTabSelect = { route ->
+              if (route == TopLevelDestinations.STUDENT) {
+                lessonViewModel.unselectLesson()
+              }
+              navigationActions.navigateTo(route)
+            },
             tabList = navigationItems,
             selectedItem = navigationActions.currentRoute())
       }) { paddingValues ->
@@ -133,7 +147,11 @@ private fun TutorSections(
   val sections =
       listOf(
           SectionInfo(
-              "Pending Confirmations",
+              "Matched Student Lessons",
+              LessonStatus.STUDENT_REQUESTED,
+              Icons.Default.Notifications),
+          SectionInfo(
+              "Waiting for Students Confirmation",
               LessonStatus.TUTOR_REQUESTED,
               ImageVector.vectorResource(id = R.drawable.baseline_access_time_24)),
           SectionInfo("Upcoming Lessons", LessonStatus.CONFIRMED, Icons.Default.Check))
@@ -149,11 +167,15 @@ private fun StudentSections(
 ) {
   val sections =
       listOf(
+          SectionInfo("Tutor Offers", LessonStatus.TUTOR_REQUESTED, Icons.Default.Notifications),
           SectionInfo(
-              "Waiting for Tutors",
+              "Waiting for Tutors Matching",
+              LessonStatus.PENDING,
+              ImageVector.vectorResource(id = R.drawable.baseline_access_time_24)),
+          SectionInfo(
+              "Waiting for Tutors Confirmation",
               LessonStatus.STUDENT_REQUESTED,
               ImageVector.vectorResource(id = R.drawable.baseline_access_time_24)),
-          SectionInfo("Tutor Offers", LessonStatus.TUTOR_REQUESTED, Icons.Default.Notifications),
           SectionInfo("Upcoming Lessons", LessonStatus.CONFIRMED, Icons.Default.Check))
 
   LessonSections(sections, lessons, false, onClick, listProfilesViewModel)

--- a/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
@@ -58,6 +58,9 @@ fun HomeScreen(
           lesson.status == LessonStatus.PENDING) {
         lessonViewModel.selectLesson(lesson)
         navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
+      } else {
+        lessonViewModel.selectLesson(lesson)
+        navigationActions.navigateTo(Screen.TUTOR_MATCH)
       }
     } else {
       if (lesson.status == LessonStatus.STUDENT_REQUESTED) {


### PR DESCRIPTION
# Add a very simple matching between student's lessons and tutor's profiles

### PR Description
This PR complete the life cycle of the lesson by implementing the matching algorithm part. For now it is a very simple algorithm that simply filter tutors based on the subject they teach and the price they want. We will need to implement a more flexible matching between the timeslots of the lesson and the availability of the tutor.

So, when the user is a student and he create a lesson (using the "Find a tutor" button), after filling all the needed fields, he will be directed to a new screen (TutorMatchingScreen in TutorMatching.kt) where he will see all the tutors that corresponds to his request (Screenshot 1). He can then click on a tutor and a pop-up will appear to confirm he want to have his lesson with this tutor (Screenshot 2). If the student chooses a tutor, it will appears in his overview in the section "Waiting for Tutor Confirmation" (STUDENT_REQUESTED state of the lesson) and from the point of view of the tutor, it will appear in the "Matched Student Lessons" section.

In order for the lesson cycle to be complete, we also need to be able (both from tutor and student side) to confirm a lesson so that we are sure that evrything is noted from both parts when a lesson is ready to be given, This is also done in this PR. To do so, I re-used screens (TutorMatchingScreen for student confirmation and TutorLessonResponseScreen for tutor confirmation) and updated them so that depending on the current state of the lesson it updates correctly the new state.

#### Modifed files
- TutorMatching.kt => screen that displays the list of matched tutors and allow the selection of one by the student. This screen is also used by the stident side to confirm a lesson 
- DisplayTutors.kt => composable that displays the given list of tutors (~DisplayLessons.kt)

- TutorLessonResponse.kt => update this screen so that it can also be used for tutor confirmation of a lesson

- AddLesson.kt => remove the save of the lesson in the database and navigate to the TutorMatchingScreen instead (which will save it in the database)

- MainActivity.kt and NavigationActions.kt => update the navigation to be able to navigate to the new screens and to the confirmation screen properly
- Overview.kt => update the section displayed on tutor and student overview to be compatible with the lesson cycle and update the function that allow us to click on a lesson either to modifiy it (only for student) or to confirm it (depending on its state)

- LessonStatus.kt and DisplayLessons.kt => remove the REQUESTED state that is now replaced by STUDENT_REQUESTED and TUTOR_REQUESTED

- LessonRepository.kt, LessonRepositoryFirestore.kt and LessonViewModel.kt=> rename the getRequestedLesson method to a more intuitive name given that the status we want is PENDING 

- LessonEditor.kt => fix the status of the updated lesson to be the same as the given lesson if any
- RequestedLessonTest.kt => fix the status of the mock lesson with status that correspond to the (current) lesson life cycle 

- EditRequestedLesson.kt => remove the lessonId parameter which is unecessary because we have the selected lesson directly in the view model

#### How to test it
The more straightforward way to test it is to run the MainActivity. The new added screen will be seen when a student create a new lesson. To test the interaction between all states and between tutor and student, the more easy way is to use two phones with two different users, one tutor and one student, and create lessons together. Note that this was already done with Alexis Rufer before publishing the PR.

#### Screenshots
![image](https://github.com/user-attachments/assets/f1298190-fcb7-4c4a-81f4-293bb4233898) ![image](https://github.com/user-attachments/assets/090348b4-5740-4dd2-9ef5-3829e7438d6a)