### PR TITLE
APK fix during CI workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Verify APK
         run: |
-          jarsigner -verify -verbose -certs app/build/outputs/apk/release/app-release-unsigned.apk
+          jarsigner -verify -verbose -certs app/build/outputs/apk/release/app-release.apk
 
       # - name: Align APK (Optional)
       #  run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,9 +70,14 @@ jobs:
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo $KEYSTORE_BASE64 | base64 --decode > ./pocketTutor-release-key.jks
 
       - name: Grant execute permission for gradlew
         run: |
@@ -89,12 +94,6 @@ jobs:
         run: |
           # To run the CI with debug information, add --info
           ./gradlew assembleDebug lint --parallel --build-cache
-
-      - name: Upload APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: APK
-          path: app/build/outputs/apk/debug/app-debug.apk
 
       - name: Run tests
         run: |
@@ -139,3 +138,24 @@ jobs:
             -Dsonar.tests=app/src/test/java,app/src/androidTest/java
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} 
+
+      - name: Build Release APK
+        run: ./gradlew assembleRelease --parallel --build-cache
+
+      - name: Sign APK
+        run: |
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
+
+      - name: Verify APK
+        run: |
+          jarsigner -verify -verbose -certs app/build/outputs/apk/release/app-release-unsigned.apk
+
+      - name: Align APK (Optional)
+        run: |
+          zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: APK
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Sign APK
         run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD -signedjar app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
 
       - name: Verify APK
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -155,7 +155,7 @@ jobs:
           zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: APK
           path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -151,9 +151,9 @@ jobs:
         run: |
           jarsigner -verify -verbose -certs app/build/outputs/apk/release/app-release-unsigned.apk
 
-      - name: Align APK (Optional)
-        run: |
-          zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
+      # - name: Align APK (Optional)
+      #  run: |
+      #    zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -139,21 +139,9 @@ jobs:
       - name: Build Release APK
         run: ./gradlew assembleRelease --parallel --build-cache
 
-      # - name: Sign APK
-      #   env:
-      #     KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-      #    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-      #     KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-      #   run: |
-      #     jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD -signedjar app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
-
       - name: Verify APK
         run: |
           jarsigner -verify -verbose -certs app/build/outputs/apk/release/app-release.apk
-
-      # - name: Align APK (Optional)
-      #  run: |
-      #    zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -139,13 +139,13 @@ jobs:
       - name: Build Release APK
         run: ./gradlew assembleRelease --parallel --build-cache
 
-      - name: Sign APK
-        env:
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-        run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD -signedjar app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
+      # - name: Sign APK
+      #   env:
+      #     KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+      #    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      #     KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      #   run: |
+      #     jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD -signedjar app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
 
       - name: Verify APK
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,9 +71,6 @@ jobs:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
@@ -143,6 +140,10 @@ jobs:
         run: ./gradlew assembleRelease --parallel --build-cache
 
       - name: Sign APK
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore pocketTutor-release-key.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD -signedjar app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,12 +39,21 @@ android {
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = "pocketTutor-key"
+            keyPassword = "pocketTutor"
+            storeFile = file("pocketTutor-release-key.jks")
+            storePassword = "pocketTutor" }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             enableUnitTestCoverage = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,17 +43,17 @@ android {
         create("release") {
             keyAlias = "pocketTutor-key"
             keyPassword = "pocketTutor"
-            storeFile = file("pocketTutor-release-key.jks")
+            storeFile = file("../pocketTutor-release-key.jks")
             storePassword = "pocketTutor" }
     }
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             enableUnitTestCoverage = true


### PR DESCRIPTION
# Update the APK file generated by the CI workflow to fix 'No Credential Available' error

### PR Context
The 'No Crendential Available' error that appear when we use the APK file generated by the CI was the consequence of two bugs that this PR aims to solve. First,  the CI was uploading the debug version of the APK which does not enable us to use the Google Sign In. Secondly, the release APK must be signed with a keylog key so that we can get the corresponding SHA1 and add it to the list of authorized SHA1 in Firebase.

### PR Description
This PR solves the two bugs related to the APK generation in the CI workflow by:
- Generating a new keylog file which is kept private but added to the Github secret 
- Adding a sign-in configuration with the generated keylog for the release version in the build.gradle.kts so that the APK produced is signed
- Using ./gradlew assembleRelease command to generate the release version of the APK and upload it to the CI

### How to test it
To test this PR, one should get the APK file generated by the last CI workflow, upload it on his phone and see if the application works as intented (and in particular check if he could sign-in with Google without any 'No Credential Available' error).