### PR TITLE
Add refresh to overview screen and improve UI in display available tutor Screen 

### DIFF
--- a/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayTutors.kt
@@ -3,17 +3,28 @@ package com.github.se.project.ui.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.se.project.model.profile.Profile
 
@@ -23,30 +34,89 @@ fun DisplayTutors(
     tutors: List<Profile>,
     onCardClick: (Profile) -> Unit = {}
 ) {
-  LazyColumn(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-    itemsIndexed(tutors) { index, tutor ->
-      Card(
-          modifier =
-              Modifier.fillMaxWidth()
-                  .padding(vertical = 2.dp)
-                  .testTag("tutorCard_$index")
-                  .clickable { onCardClick(tutor) },
-          colors =
-              CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceBright)) {
-            Column(
-                modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("tutorContent_$index"),
-                verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                  Text(
-                      text = tutor.firstName + " " + tutor.lastName,
-                      style = MaterialTheme.typography.titleMedium,
-                      modifier = Modifier.testTag("tutorName_$index"))
+  LazyColumn(
+      modifier = modifier.fillMaxWidth(),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+      contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+        itemsIndexed(tutors) { index, tutor ->
+          Card(
+              modifier =
+                  Modifier.fillMaxWidth().testTag("tutorCard_$index").clickable {
+                    onCardClick(tutor)
+                  },
+              colors =
+                  CardDefaults.cardColors(
+                      containerColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha = 0.45f)),
+              shape = MaterialTheme.shapes.medium) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top) {
+                      // Left side: Profile picture and info
+                      Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        // Profile Picture
+                        Surface(
+                            modifier = Modifier.size(40.dp),
+                            shape = CircleShape,
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)) {
+                              Icon(
+                                  imageVector = Icons.Default.Person,
+                                  contentDescription = null,
+                                  modifier = Modifier.padding(8.dp),
+                                  tint = MaterialTheme.colorScheme.primary)
+                            }
 
-                  Text(
-                      text = tutor.section.toString() + " " + tutor.academicLevel.toString(),
-                      style = MaterialTheme.typography.bodyLarge,
-                      modifier = Modifier.testTag("tutorLevel_$index"))
-                }
-          }
-    }
-  }
+                        // Tutor Information
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                          // Name
+                          Text(
+                              text = "${tutor.firstName} ${tutor.lastName}",
+                              style = MaterialTheme.typography.titleMedium,
+                              modifier = Modifier.testTag("tutorName_$index"))
+
+                          // Section and Level
+                          Row(
+                              horizontalArrangement = Arrangement.spacedBy(8.dp),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                Surface(
+                                    shape = RoundedCornerShape(4.dp),
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)) {
+                                      Text(
+                                          text = tutor.section.toString(),
+                                          style = MaterialTheme.typography.labelSmall,
+                                          modifier =
+                                              Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                          color = MaterialTheme.colorScheme.primary)
+                                    }
+
+                                Text(
+                                    text = tutor.academicLevel.toString(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                              }
+
+                          // Subjects
+                          Text(
+                              text = tutor.subjects.joinToString(", ") { it.name.lowercase() },
+                              style = MaterialTheme.typography.bodySmall,
+                              color = MaterialTheme.colorScheme.onSurfaceVariant,
+                              maxLines = 1,
+                              overflow = TextOverflow.Ellipsis)
+                        }
+                      }
+
+                      // Price tag
+                      Surface(
+                          shape = MaterialTheme.shapes.medium,
+                          color = MaterialTheme.colorScheme.primary) {
+                            Text(
+                                text = "${tutor.price}.-/h",
+                                style = MaterialTheme.typography.titleSmall,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                color = MaterialTheme.colorScheme.onPrimary)
+                          }
+                    }
+              }
+        }
+      }
 }

--- a/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
@@ -7,8 +7,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,6 +29,8 @@ import com.github.se.project.model.lesson.*
 import com.github.se.project.model.profile.*
 import com.github.se.project.ui.components.DisplayLessons
 import com.github.se.project.ui.navigation.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -111,7 +117,8 @@ fun HomeScreen(
                 lessons = lessons,
                 onClick = onLessonClick,
                 paddingValues = paddingValues,
-                listProfilesViewModel = listProfileViewModel)
+                listProfilesViewModel = listProfileViewModel,
+                lessonViewModel = lessonViewModel)
           } else {
             EmptyLessonsState(paddingValues)
           }
@@ -119,21 +126,40 @@ fun HomeScreen(
       }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun LessonsContent(
     profile: Profile,
     lessons: List<Lesson>,
     onClick: (Lesson) -> Unit,
     paddingValues: PaddingValues,
-    listProfilesViewModel: ListProfilesViewModel
+    listProfilesViewModel: ListProfilesViewModel,
+    lessonViewModel: LessonViewModel
 ) {
+  var refreshing by remember { mutableStateOf(false) }
+  val refreshScope = rememberCoroutineScope()
+
+  fun refresh() =
+      refreshScope.launch {
+        refreshing = true
+        when (profile.role) {
+          Role.TUTOR -> lessonViewModel.getLessonsForTutor(profile.uid)
+          Role.STUDENT -> lessonViewModel.getLessonsForStudent(profile.uid)
+          else -> {}
+        }
+        delay(1000)
+        refreshing = false
+      }
+
+  val pullRefreshState = rememberPullRefreshState(refreshing, ::refresh)
+
   Column(
       modifier =
           Modifier.fillMaxSize()
               .padding(paddingValues)
               .padding(horizontal = 16.dp)
               .testTag("lessonsColumn")) {
-        Box(modifier = Modifier.fillMaxSize().weight(1f)) {
+        Box(modifier = Modifier.fillMaxSize().weight(1f).pullRefresh(pullRefreshState)) {
           Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
             if (profile.role == Role.TUTOR) {
               TutorSections(lessons, onClick, listProfilesViewModel)
@@ -141,6 +167,13 @@ private fun LessonsContent(
               StudentSections(lessons, onClick, listProfilesViewModel)
             }
           }
+
+          PullRefreshIndicator(
+              refreshing = refreshing,
+              state = pullRefreshState,
+              modifier = Modifier.align(Alignment.TopCenter),
+              backgroundColor = MaterialTheme.colorScheme.surface,
+              contentColor = MaterialTheme.colorScheme.primary)
         }
       }
 }


### PR DESCRIPTION
# Pull Request: Add Pull-to-Refresh & Enhanced Tutor Cards Design

## Changes Overview
This PR implements two main features:
1. Pull-to-refresh functionality in the Overview screen
2. Enhanced visual design for tutor cards with improved layout and readability

### Pull-to-Refresh Implementation
- Added native Material 3 pull-to-refresh functionality
- Implemented automatic data refresh based on user role (Student/Tutor)
- Added visual feedback during refresh operations
- Smooth animations and transitions

### Tutor Cards Redesign
- Improved layout with profile picture placeholder
- Better visual hierarchy
- Added subject list with ellipsis for overflow
- Enhanced section and academic level display
- Added prominent price tag
- Reduced card borders and improved spacing
- Adjusted color scheme for better contrast

## Technical Details
- Used `pullRefresh` and `PullRefreshIndicator` from Material 3 
- Added coroutine scope for managing refresh operations
- Implemented state management for refresh operations
- Enhanced styling using MaterialTheme
- Improved reusability of components

## Testing
- Verified pull-to-refresh functionality works correctly for both student and tutor roles
- Tested visual consistency across different screen sizes
- Ensured proper state management during refresh operations