### PR TITLE
Prevent tutorUid to automatically reset in LessonEditor when editing a Lesson

### DIFF
--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -24,7 +24,6 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
   private val _selectedLesson = MutableStateFlow<Lesson?>(null)
   open val selectedLesson: StateFlow<Lesson?> = _selectedLesson.asStateFlow()
 
-
   init {
     repository.init {}
   }

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -24,16 +24,6 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
   private val _selectedLesson = MutableStateFlow<Lesson?>(null)
   open val selectedLesson: StateFlow<Lesson?> = _selectedLesson.asStateFlow()
 
-  // StateFlow to observe selected location changes
-  // Default value is currently set to Lausanne EPFL
-  // TODO: Change default value to user's current location
-  private val _selectedLocation = MutableStateFlow<Pair<Double, Double>>(46.520374 to 6.568339)
-  open val selectedLocation = _selectedLocation.asStateFlow()
-
-  // Function to update location
-  fun updateSelectedLocation(location: Pair<Double, Double>) {
-    _selectedLocation.value = location
-  }
 
   init {
     repository.init {}

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -71,7 +71,9 @@ fun LessonEditor(
   var title by remember { mutableStateOf(lesson?.title ?: "") }
   var description by remember { mutableStateOf(lesson?.description ?: "") }
   val selectedLanguages = remember { mutableStateListOf<Language>() }
-    val tutorUid = remember { mutableStateListOf<String>().apply { lesson?.tutorUid?.let { addAll(it) } } }
+  val tutorUid = remember {
+    mutableStateListOf<String>().apply { lesson?.tutorUid?.let { addAll(it) } }
+  }
   val selectedSubject = remember { mutableStateOf(lesson?.subject ?: Subject.NONE) }
   var minPrice by remember { mutableDoubleStateOf(lesson?.minPrice ?: 5.0) }
   var maxPrice by remember { mutableDoubleStateOf(lesson?.maxPrice ?: 50.0) }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -71,6 +71,7 @@ fun LessonEditor(
   var title by remember { mutableStateOf(lesson?.title ?: "") }
   var description by remember { mutableStateOf(lesson?.description ?: "") }
   val selectedLanguages = remember { mutableStateListOf<Language>() }
+    val tutorUid = remember { mutableStateListOf<String>().apply { lesson?.tutorUid?.let { addAll(it) } } }
   val selectedSubject = remember { mutableStateOf(lesson?.subject ?: Subject.NONE) }
   var minPrice by remember { mutableDoubleStateOf(lesson?.minPrice ?: 5.0) }
   var maxPrice by remember { mutableDoubleStateOf(lesson?.maxPrice ?: 50.0) }
@@ -167,7 +168,7 @@ fun LessonEditor(
               description,
               selectedSubject.value,
               selectedLanguages.toList(),
-              listOf(),
+              tutorUid,
               profile.uid,
               minPrice,
               maxPrice,

--- a/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/EditRequestedLesson.kt
@@ -19,7 +19,6 @@ fun EditRequestedLessonScreen(
 ) {
 
   val profile = listProfilesViewModel.currentProfile.collectAsState()
-  val selectedLocation by lessonViewModel.selectedLocation.collectAsState()
 
   val currentLesson =
       lessonViewModel.selectedLesson.collectAsState().value


### PR DESCRIPTION
## Description

This PR fixes a bug in the `LessonEditor` composable where the `tutorUid` field was incorrectly resetting to an empty list when a student edited an unapproved lesson. This behavior would cause the lesson to "disappear" any tutor’s view, as the tutor UID was removed upon edit.

## Bug Details

- **File**: `LessonEditor.kt`
- **Issue**:
  - When a student edits a lesson that has not yet been approved by a tutor, the `tutorUid` was unintentionally reset to an empty list.
  - This caused issues in lesson assignment and visibility since the tutor UID was no longer linked to the lesson.

- **Root Cause**:
  - The initialization of `tutorUid` was not define, which defaulted to an empty list, rather than preserving the existing tutor UID.

- **Files**: `LessonViewModel.kt` and  `EditRequestedLesson.kt`
- **Issue**:
  -  remove unecessary variables and unused variables to avoid confusion when debugging

## Solution

1. Updated the `tutorUid` initialization to correctly retain the existing tutor UID from the `lesson` object if available.
2. Specifically:
   - Created an empty mutable state list with `mutableStateListOf<String>()`.
   - Used `.apply { lesson?.tutorUid?.let { addAll(it) } }` to add any existing tutor UIDs if `lesson?.tutorUid` is non-null.

