### PR TITLE
Add the user's location alongside the Lesson Location on the Google Map screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,9 @@ dependencies {
     implementation(libs.maps.compose.utils)
     implementation(libs.play.services.auth)
     implementation(libs.google.identity)
+    implementation(libs.play.services.location)
+
+
 
     // Firebase
     implementation(libs.firebase.database.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -148,7 +148,6 @@ fun getCameraPositionForBothLocations(
     //adjust the zoom level to fit both locations
 
 
-
     // Adjust the camera to fit both locations
     return CameraPosition.fromLatLngZoom(bounds.center, 10f) // Set a zoom level that works for both locations
 }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -73,7 +73,6 @@ fun LessonLocationDisplay(
         }
   }
 
-  // Map UI
   if (isLocationChecked) {
     Column(modifier = modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(text = "Lesson Location", style = MaterialTheme.typography.titleMedium)
@@ -102,7 +101,6 @@ fun LessonLocationDisplay(
   }
 }
 
-
 /**
  * Utility function to calculate the bounds to show both the user's location and lesson location,
  * and update the camera position to fit them.
@@ -111,70 +109,70 @@ fun getCameraPositionForBothLocations(
     userLocation: LatLng?,
     lessonLocation: LatLng,
 ): CameraPosition {
-    // If we don't have the user's location, just focus on the lesson location
-    if (userLocation == null) {
-        return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
-    }
+  // If we don't have the user's location, just focus on the lesson location
+  if (userLocation == null) {
+    return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+  }
 
-    // Otherwise, calculate the bounds to fit both locations
-    val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
-    val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
+  // Otherwise, calculate the bounds to fit both locations
+  val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
+  val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
 
-    // Get the bounds to show both locations
-    val latMin = latitudes.minOrNull() ?: userLocation.latitude
-    val latMax = latitudes.maxOrNull() ?: userLocation.latitude
-    val lonMin = longitudes.minOrNull() ?: userLocation.longitude
-    val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
+  // Get the bounds to show both locations
+  val latMin = latitudes.minOrNull() ?: userLocation.latitude
+  val latMax = latitudes.maxOrNull() ?: userLocation.latitude
+  val lonMin = longitudes.minOrNull() ?: userLocation.longitude
+  val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
 
-    // Create the bounds
-    val bounds = LatLngBounds(LatLng(latMin, lonMin), LatLng(latMax, lonMax))
+  // Create the bounds
+  val bounds = LatLngBounds(LatLng(latMin, lonMin), LatLng(latMax, lonMax))
 
-    // Calculate the zoom level based on the distance between the two locations
-    val distance = calculateDistance(userLocation, lessonLocation)
-    val zoomLevel = adjustZoomBasedOnDistance(distance)
+  // Calculate the zoom level based on the distance between the two locations
+  val distance = calculateDistance(userLocation, lessonLocation)
+  val zoomLevel = adjustZoomBasedOnDistance(distance)
 
-    // Adjust the camera to fit both locations with appropriate zoom
-    return CameraPosition.fromLatLngZoom(bounds.center, zoomLevel)
+  // Adjust the camera to fit both locations with appropriate zoom
+  return CameraPosition.fromLatLngZoom(bounds.center, zoomLevel)
 }
 
-/**
- * Private function to calculate the distance (in meters) between two locations.
- */
+/** Private function to calculate the distance (in meters) between two locations. */
 fun calculateDistance(userLocation: LatLng?, lessonLocation: LatLng): Float {
-    if (userLocation == null) return 0f
+  if (userLocation == null) return 0f
 
-    val lat1 = userLocation.latitude
-    val lon1 = userLocation.longitude
-    val lat2 = lessonLocation.latitude
-    val lon2 = lessonLocation.longitude
+  val lat1 = userLocation.latitude
+  val lon1 = userLocation.longitude
+  val lat2 = lessonLocation.latitude
+  val lon2 = lessonLocation.longitude
 
-    val earthRadius = 6371 // Radius of the Earth in kilometers
-    val latDiff = Math.toRadians(lat2 - lat1)
-    val lonDiff = Math.toRadians(lon2 - lon1)
+  val earthRadius = 6371 // Radius of the Earth in kilometers
+  val latDiff = Math.toRadians(lat2 - lat1)
+  val lonDiff = Math.toRadians(lon2 - lon1)
 
-    val a = sin(latDiff / 2).pow(2.0) + cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(lonDiff / 2).pow(2.0)
-    val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+  val a =
+      sin(latDiff / 2).pow(2.0) +
+          cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(lonDiff / 2).pow(2.0)
+  val c = 2 * atan2(sqrt(a), sqrt(1 - a))
 
-    // Distance in kilometers
-    val distanceInKm = earthRadius * c
+  // Distance in kilometers
+  val distanceInKm = earthRadius * c
 
-    // Convert to meters
-    return (distanceInKm * 1000).toFloat()
+  // Convert to meters
+  return (distanceInKm * 1000).toFloat()
 }
 
 /**
- * Private function to adjust the zoom level based on the distance between two locations.
- * The further the locations, the lower the zoom level.
+ * Private function to adjust the zoom level based on the distance between two locations. The
+ * further the locations, the lower the zoom level.
  */
 fun adjustZoomBasedOnDistance(distance: Float): Float {
-    return when {
-        distance < 100 -> 15f // If the distance is less than 100 meters, zoom in more
-        distance < 500 -> 14f // If the distance is between 100-500 meters, zoom in a bit
-        distance < 2000 -> 12f // If the distance is between 500m-2km, zoom out a bit
-        distance < 10000 -> 10f // If the distance is between 2km-10km, zoom out even more
-        distance < 20000 -> 8f // If the distance is between 10km-20km, zoom out further
-        distance < 50000 -> 7f // If the distance is between 20km-50km, zoom out even further
-        distance < 100000 -> 6f // If the distance is between 50km-100km, zoom out even further
-        else -> 5f // If the distance is more than 100km, zoom out further
-    }
+  return when {
+    distance < 100 -> 15f // If the distance is less than 100 meters, zoom in more
+    distance < 500 -> 14f // If the distance is between 100-500 meters, zoom in a bit
+    distance < 2000 -> 12f // If the distance is between 500m-2km, zoom out a bit
+    distance < 10000 -> 10f // If the distance is between 2km-10km, zoom out even more
+    distance < 20000 -> 8f // If the distance is between 10km-20km, zoom out further
+    distance < 50000 -> 7f // If the distance is between 20km-50km, zoom out even further
+    distance < 100000 -> 6f // If the distance is between 50km-100km, zoom out even further
+    else -> 5f // If the distance is more than 100km, zoom out further
+  }
 }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -1,19 +1,33 @@
 package com.github.se.project.ui.components
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.Location
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.Priority
+import com.google.android.gms.maps.model.LatLngBounds
 
 /**
- * A component that displays a static Google Map showing the lesson location
+ * A component that displays a Google Map showing the lesson location and user's location
  *
  * @param latitude The latitude coordinate of the lesson location
  * @param longitude The longitude coordinate of the lesson location
+ * @param lessonTitle The title for the lesson
  * @param modifier Optional modifier for the component
  */
 @Composable
@@ -23,33 +37,144 @@ fun LessonLocationDisplay(
     lessonTitle: String,
     modifier: Modifier = Modifier
 ) {
-  val location = LatLng(latitude, longitude)
-  val cameraPositionState = rememberCameraPositionState {
-    position = CameraPosition.fromLatLngZoom(location, 15f)
-  }
+    val context = LocalContext.current
 
-  Column(modifier = modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-    Text(text = "Lesson Location", style = MaterialTheme.typography.titleMedium)
+    var userLocation by remember { mutableStateOf<LatLng?>(null) }
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-          Box(modifier = Modifier.fillMaxWidth().height(200.dp)) {
-            GoogleMap(
-                modifier = Modifier.fillMaxSize(),
-                cameraPositionState = cameraPositionState,
-                properties = MapProperties(isMyLocationEnabled = false),
-                uiSettings =
-                    MapUiSettings(
+    val lessonLocation = LatLng(latitude, longitude)
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+    }
+
+    // Request for location permission launcher
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            fetchUserLocation(context) { location ->
+                //location is null currently
+                location?.let {
+                    userLocation = LatLng(it.latitude, it.longitude)
+
+
+                    // Call the utility function to update the camera position
+                    cameraPositionState.position = getCameraPositionForBothLocations(
+                        userLocation = userLocation,
+                        lessonLocation = lessonLocation,
+                        currentCameraPosition = cameraPositionState.position
+                    )
+                }
+            }
+        }
+    }
+
+    // Request location permission if not granted
+    LaunchedEffect(Unit) {
+        locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    // If the permission is already granted (user location is known), update the camera position
+    LaunchedEffect(userLocation) {
+        // If the user location is available and it's not null
+        if (userLocation != null) {
+            cameraPositionState.position = getCameraPositionForBothLocations(
+                userLocation = userLocation,
+                lessonLocation = lessonLocation,
+                currentCameraPosition = cameraPositionState.position
+            )
+        }
+    }
+
+    // Map UI
+    Column(modifier = modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(text = "Lesson Location", style = MaterialTheme.typography.titleMedium)
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Box(modifier = Modifier.fillMaxWidth().height(200.dp)) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize(),
+                    cameraPositionState = cameraPositionState,
+                    properties = MapProperties(isMyLocationEnabled = true), // Automatically show user's location
+                    uiSettings = MapUiSettings(
                         zoomControlsEnabled = false,
                         scrollGesturesEnabled = false,
                         zoomGesturesEnabled = false,
                         tiltGesturesEnabled = false,
-                        rotationGesturesEnabled = false,
-                    )) {
-                  Marker(state = MarkerState(position = location), title = lessonTitle)
+                        rotationGesturesEnabled = false
+                    )
+                ) {
+                    // Marker for the lesson location
+                    Marker(state = MarkerState(position = lessonLocation), title = lessonTitle)
+
+
                 }
-          }
+            }
         }
-  }
+    }
 }
+
+/**
+ * Utility function to calculate the bounds to show both the user's location and lesson location,
+ * and update the camera position to fit them.
+ */
+fun getCameraPositionForBothLocations(
+    userLocation: LatLng?,
+    lessonLocation: LatLng,
+    currentCameraPosition: CameraPosition? = null
+): CameraPosition {
+    // If we don't have the user's location, just focus on the lesson location
+    if (userLocation == null) {
+        return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+    }
+
+    // Otherwise, calculate the bounds to fit both locations
+    val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
+    val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
+
+    // Get the bounds to show both locations
+    val latMin = latitudes.minOrNull() ?: userLocation.latitude
+    val latMax = latitudes.maxOrNull() ?: userLocation.latitude
+    val lonMin = longitudes.minOrNull() ?: userLocation.longitude
+    val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
+
+    // Create the bounds
+    val bounds = LatLngBounds(
+        LatLng(latMin, lonMin),
+        LatLng(latMax, lonMax)
+    )
+    //adjust the zoom level to fit both locations
+
+
+
+    // Adjust the camera to fit both locations
+    return CameraPosition.fromLatLngZoom(bounds.center, 10f) // Set a zoom level that works for both locations
+}
+
+/**
+ * Fetches the user's current location using the FusedLocationProviderClient.
+ */
+private fun fetchUserLocation(context: android.content.Context, onLocationReceived: (Location?) -> Unit) {
+    val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+        // Permission is granted, get the location
+        fusedLocationClient.getCurrentLocation(Priority. PRIORITY_HIGH_ACCURACY , null)
+            .addOnSuccessListener { location: Location? ->
+                //TODO: In case the user has not allow its phone to share its location the location will be null
+                Toast.makeText(context, "User location received", Toast.LENGTH_SHORT).show()
+                onLocationReceived(location)
+            }
+            .addOnFailureListener {
+                Toast.makeText(context, "User location not available", Toast.LENGTH_SHORT).show()
+                onLocationReceived(null)
+            }
+    } else {
+        // If permission is not granted, return null
+        Toast.makeText(context, "Permission is not granted", Toast.LENGTH_SHORT).show()
+        onLocationReceived(null)
+    }
+}
+

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -28,6 +28,11 @@ import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 /**
  * A component that displays a Google Map showing the lesson location and user's location
@@ -97,6 +102,7 @@ fun LessonLocationDisplay(
   }
 }
 
+
 /**
  * Utility function to calculate the bounds to show both the user's location and lesson location,
  * and update the camera position to fit them.
@@ -105,26 +111,70 @@ fun getCameraPositionForBothLocations(
     userLocation: LatLng?,
     lessonLocation: LatLng,
 ): CameraPosition {
-  // If we don't have the user's location, just focus on the lesson location
-  if (userLocation == null) {
-    return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
-  }
+    // If we don't have the user's location, just focus on the lesson location
+    if (userLocation == null) {
+        return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+    }
 
-  // Otherwise, calculate the bounds to fit both locations
-  val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
-  val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
+    // Otherwise, calculate the bounds to fit both locations
+    val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
+    val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
 
-  // Get the bounds to show both locations
-  val latMin = latitudes.minOrNull() ?: userLocation.latitude
-  val latMax = latitudes.maxOrNull() ?: userLocation.latitude
-  val lonMin = longitudes.minOrNull() ?: userLocation.longitude
-  val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
+    // Get the bounds to show both locations
+    val latMin = latitudes.minOrNull() ?: userLocation.latitude
+    val latMax = latitudes.maxOrNull() ?: userLocation.latitude
+    val lonMin = longitudes.minOrNull() ?: userLocation.longitude
+    val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
 
-  // Create the bounds
-  val bounds = LatLngBounds(LatLng(latMin, lonMin), LatLng(latMax, lonMax))
-  // adjust the zoom level to fit both locations
+    // Create the bounds
+    val bounds = LatLngBounds(LatLng(latMin, lonMin), LatLng(latMax, lonMax))
 
-  // Adjust the camera to fit both locations
-  return CameraPosition.fromLatLngZoom(
-      bounds.center, 10f) // Set a zoom level that works for both locations
+    // Calculate the zoom level based on the distance between the two locations
+    val distance = calculateDistance(userLocation, lessonLocation)
+    val zoomLevel = adjustZoomBasedOnDistance(distance)
+
+    // Adjust the camera to fit both locations with appropriate zoom
+    return CameraPosition.fromLatLngZoom(bounds.center, zoomLevel)
+}
+
+/**
+ * Private function to calculate the distance (in meters) between two locations.
+ */
+fun calculateDistance(userLocation: LatLng?, lessonLocation: LatLng): Float {
+    if (userLocation == null) return 0f
+
+    val lat1 = userLocation.latitude
+    val lon1 = userLocation.longitude
+    val lat2 = lessonLocation.latitude
+    val lon2 = lessonLocation.longitude
+
+    val earthRadius = 6371 // Radius of the Earth in kilometers
+    val latDiff = Math.toRadians(lat2 - lat1)
+    val lonDiff = Math.toRadians(lon2 - lon1)
+
+    val a = sin(latDiff / 2).pow(2.0) + cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(lonDiff / 2).pow(2.0)
+    val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+    // Distance in kilometers
+    val distanceInKm = earthRadius * c
+
+    // Convert to meters
+    return (distanceInKm * 1000).toFloat()
+}
+
+/**
+ * Private function to adjust the zoom level based on the distance between two locations.
+ * The further the locations, the lower the zoom level.
+ */
+fun adjustZoomBasedOnDistance(distance: Float): Float {
+    return when {
+        distance < 100 -> 15f // If the distance is less than 100 meters, zoom in more
+        distance < 500 -> 14f // If the distance is between 100-500 meters, zoom in a bit
+        distance < 2000 -> 12f // If the distance is between 500m-2km, zoom out a bit
+        distance < 10000 -> 10f // If the distance is between 2km-10km, zoom out even more
+        distance < 20000 -> 8f // If the distance is between 10km-20km, zoom out further
+        distance < 50000 -> 7f // If the distance is between 20km-50km, zoom out even further
+        distance < 100000 -> 6f // If the distance is between 50km-100km, zoom out even further
+        else -> 5f // If the distance is more than 100km, zoom out further
+    }
 }

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -1,26 +1,33 @@
 package com.github.se.project.ui.components
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.location.Location
-import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.google.android.gms.location.LocationServices
+import com.github.se.project.ui.map.LocationPermissionHandler
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.*
-import androidx.compose.ui.platform.LocalContext
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
-import com.google.android.gms.location.LocationRequest
-import com.google.android.gms.location.Priority
 import com.google.android.gms.maps.model.LatLngBounds
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
 
 /**
  * A component that displays a Google Map showing the lesson location and user's location
@@ -37,83 +44,57 @@ fun LessonLocationDisplay(
     lessonTitle: String,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
+  var userLocation by remember { mutableStateOf<LatLng?>(null) }
+  var isLocationChecked by remember { mutableStateOf(false) }
 
-    var userLocation by remember { mutableStateOf<LatLng?>(null) }
+  val lessonLocation = LatLng(latitude, longitude)
 
-    val lessonLocation = LatLng(latitude, longitude)
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(lessonLocation, 10f)
-    }
+  val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+  }
 
-    // Request for location permission launcher
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        if (isGranted) {
-            fetchUserLocation(context) { location ->
-                //location is null currently
-                location?.let {
-                    userLocation = LatLng(it.latitude, it.longitude)
+  // Request for location permission launcher
+  LocationPermissionHandler { location ->
+    userLocation = location
+    isLocationChecked = true
 
-
-                    // Call the utility function to update the camera position
-                    cameraPositionState.position = getCameraPositionForBothLocations(
-                        userLocation = userLocation,
-                        lessonLocation = lessonLocation,
-                        currentCameraPosition = cameraPositionState.position
-                    )
-                }
-            }
+    // Update the camera position based on user location availability
+    cameraPositionState.position =
+        if (location != null) {
+          getCameraPositionForBothLocations(
+              userLocation = location, lessonLocation = lessonLocation)
+        } else {
+          CameraPosition.fromLatLngZoom(lessonLocation, 10f)
         }
-    }
+  }
 
-    // Request location permission if not granted
-    LaunchedEffect(Unit) {
-        locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-    }
-
-    // If the permission is already granted (user location is known), update the camera position
-    LaunchedEffect(userLocation) {
-        // If the user location is available and it's not null
-        if (userLocation != null) {
-            cameraPositionState.position = getCameraPositionForBothLocations(
-                userLocation = userLocation,
-                lessonLocation = lessonLocation,
-                currentCameraPosition = cameraPositionState.position
-            )
-        }
-    }
-
-    // Map UI
+  // Map UI
+  if (isLocationChecked) {
     Column(modifier = modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(text = "Lesson Location", style = MaterialTheme.typography.titleMedium)
+      Text(text = "Lesson Location", style = MaterialTheme.typography.titleMedium)
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-        ) {
+      Card(
+          modifier = Modifier.fillMaxWidth(),
+          elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
             Box(modifier = Modifier.fillMaxWidth().height(200.dp)) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize(),
-                    cameraPositionState = cameraPositionState,
-                    properties = MapProperties(isMyLocationEnabled = true), // Automatically show user's location
-                    uiSettings = MapUiSettings(
-                        zoomControlsEnabled = false,
-                        scrollGesturesEnabled = false,
-                        zoomGesturesEnabled = false,
-                        tiltGesturesEnabled = false,
-                        rotationGesturesEnabled = false
-                    )
-                ) {
+              GoogleMap(
+                  modifier = Modifier.fillMaxSize(),
+                  cameraPositionState = cameraPositionState,
+                  properties = MapProperties(isMyLocationEnabled = (userLocation != null)),
+                  uiSettings =
+                      MapUiSettings(
+                          zoomControlsEnabled = false,
+                          scrollGesturesEnabled = false,
+                          zoomGesturesEnabled = false,
+                          tiltGesturesEnabled = false,
+                          rotationGesturesEnabled = false)) {
                     // Marker for the lesson location
                     Marker(state = MarkerState(position = lessonLocation), title = lessonTitle)
-
-
-                }
+                  }
             }
-        }
+          }
     }
+  }
 }
 
 /**
@@ -123,57 +104,27 @@ fun LessonLocationDisplay(
 fun getCameraPositionForBothLocations(
     userLocation: LatLng?,
     lessonLocation: LatLng,
-    currentCameraPosition: CameraPosition? = null
 ): CameraPosition {
-    // If we don't have the user's location, just focus on the lesson location
-    if (userLocation == null) {
-        return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
-    }
+  // If we don't have the user's location, just focus on the lesson location
+  if (userLocation == null) {
+    return CameraPosition.fromLatLngZoom(lessonLocation, 10f)
+  }
 
-    // Otherwise, calculate the bounds to fit both locations
-    val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
-    val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
+  // Otherwise, calculate the bounds to fit both locations
+  val latitudes = listOf(userLocation.latitude, lessonLocation.latitude)
+  val longitudes = listOf(userLocation.longitude, lessonLocation.longitude)
 
-    // Get the bounds to show both locations
-    val latMin = latitudes.minOrNull() ?: userLocation.latitude
-    val latMax = latitudes.maxOrNull() ?: userLocation.latitude
-    val lonMin = longitudes.minOrNull() ?: userLocation.longitude
-    val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
+  // Get the bounds to show both locations
+  val latMin = latitudes.minOrNull() ?: userLocation.latitude
+  val latMax = latitudes.maxOrNull() ?: userLocation.latitude
+  val lonMin = longitudes.minOrNull() ?: userLocation.longitude
+  val lonMax = longitudes.maxOrNull() ?: userLocation.longitude
 
-    // Create the bounds
-    val bounds = LatLngBounds(
-        LatLng(latMin, lonMin),
-        LatLng(latMax, lonMax)
-    )
-    //adjust the zoom level to fit both locations
+  // Create the bounds
+  val bounds = LatLngBounds(LatLng(latMin, lonMin), LatLng(latMax, lonMax))
+  // adjust the zoom level to fit both locations
 
-
-    // Adjust the camera to fit both locations
-    return CameraPosition.fromLatLngZoom(bounds.center, 10f) // Set a zoom level that works for both locations
+  // Adjust the camera to fit both locations
+  return CameraPosition.fromLatLngZoom(
+      bounds.center, 10f) // Set a zoom level that works for both locations
 }
-
-/**
- * Fetches the user's current location using the FusedLocationProviderClient.
- */
-private fun fetchUserLocation(context: android.content.Context, onLocationReceived: (Location?) -> Unit) {
-    val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
-
-    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-        // Permission is granted, get the location
-        fusedLocationClient.getCurrentLocation(Priority. PRIORITY_HIGH_ACCURACY , null)
-            .addOnSuccessListener { location: Location? ->
-                //TODO: In case the user has not allow its phone to share its location the location will be null
-                Toast.makeText(context, "User location received", Toast.LENGTH_SHORT).show()
-                onLocationReceived(location)
-            }
-            .addOnFailureListener {
-                Toast.makeText(context, "User location not available", Toast.LENGTH_SHORT).show()
-                onLocationReceived(null)
-            }
-    } else {
-        // If permission is not granted, return null
-        Toast.makeText(context, "Permission is not granted", Toast.LENGTH_SHORT).show()
-        onLocationReceived(null)
-    }
-}
-

--- a/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonLocationDisplay.kt
@@ -35,7 +35,7 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
- * A component that displays a Google Map showing the lesson location and user's location
+ * A component that displays a map showing the lesson's location and the user's location
  *
  * @param latitude The latitude coordinate of the lesson location
  * @param longitude The longitude coordinate of the lesson location

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
@@ -1,0 +1,68 @@
+package com.github.se.project.ui.map
+
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.github.se.project.Manifest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.maps.model.LatLng
+import android.location.Location
+
+@Composable
+fun LocationPermissionHandler(
+    onLocationAvailable: (LatLng?) -> Unit
+) {
+    val context = LocalContext.current
+    var hasPermission by remember { mutableStateOf(false) }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        hasPermission = isGranted
+        if (isGranted) {
+            fetchUserLocation(context, onLocationAvailable)
+        } else {
+            onLocationAvailable(null) // Permission denied
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            hasPermission = true
+            fetchUserLocation(context, onLocationAvailable)
+        } else {
+            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    fun fetchUserLocation(context: android.content.Context, onLocationReceived: (LatLng?) -> Unit) {
+        val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
+                .addOnSuccessListener { location: Location? ->
+                    if (location != null) {
+                        onLocationReceived(LatLng(location.latitude, location.longitude))
+                    } else {
+                        Toast.makeText(context, "Location not available", Toast.LENGTH_SHORT).show()
+                        onLocationReceived(null)
+                    }
+                }
+                .addOnFailureListener {
+                    Toast.makeText(context, "Failed to retrieve location", Toast.LENGTH_SHORT).show()
+                    onLocationReceived(null)
+                }
+        } else {
+            Toast.makeText(context, "Location permission not granted", Toast.LENGTH_SHORT).show()
+            onLocationReceived(null)
+        }
+    }
+
+}

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
@@ -54,7 +54,8 @@ fun fetchUserLocation(context: android.content.Context, onLocationReceived: (Lat
           if (location != null) {
             onLocationReceived(LatLng(location.latitude, location.longitude))
           } else {
-            Toast.makeText(context, "Location not available", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, "Location of your phone is not activated", Toast.LENGTH_SHORT)
+                .show()
             onLocationReceived(null)
           }
         }
@@ -63,8 +64,7 @@ fun fetchUserLocation(context: android.content.Context, onLocationReceived: (Lat
           onLocationReceived(null)
         }
   } else {
-    Toast.makeText(context, "Location permission was not granted by the user", Toast.LENGTH_SHORT)
-        .show()
+    Toast.makeText(context, "Location permission was not granted", Toast.LENGTH_SHORT).show()
     onLocationReceived(null)
   }
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPermissionHandler.kt
@@ -1,68 +1,70 @@
 package com.github.se.project.ui.map
 
+import android.Manifest
 import android.content.pm.PackageManager
+import android.location.Location
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
-import com.github.se.project.Manifest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.maps.model.LatLng
-import android.location.Location
 
 @Composable
-fun LocationPermissionHandler(
-    onLocationAvailable: (LatLng?) -> Unit
-) {
-    val context = LocalContext.current
-    var hasPermission by remember { mutableStateOf(false) }
+fun LocationPermissionHandler(onLocationAvailable: (LatLng?) -> Unit) {
+  val context = LocalContext.current
 
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        hasPermission = isGranted
+  // Launcher that ask user for location permission
+  val locationPermissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted
+        -> // isGranted represents the user’s response to the permission request
         if (isGranted) {
-            fetchUserLocation(context, onLocationAvailable)
-        } else {
-            onLocationAvailable(null) // Permission denied
+          fetchUserLocation(context, onLocationAvailable)
+        } else { // Permission denied by the user or the system
+          onLocationAvailable(null)
         }
+      }
+
+  LaunchedEffect(Unit) {
+    // Check if location permission was already granted by the user
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED) {
+      fetchUserLocation(context, onLocationAvailable)
+    } else {
+      // In case location permission is not granted, ask user for it
+      locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
     }
+  }
+}
 
-    LaunchedEffect(Unit) {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            hasPermission = true
-            fetchUserLocation(context, onLocationAvailable)
-        } else {
-            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-        }
-    }
+fun fetchUserLocation(context: android.content.Context, onLocationReceived: (LatLng?) -> Unit) {
+  val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
 
-    fun fetchUserLocation(context: android.content.Context, onLocationReceived: (LatLng?) -> Unit) {
-        val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
-
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
-                .addOnSuccessListener { location: Location? ->
-                    if (location != null) {
-                        onLocationReceived(LatLng(location.latitude, location.longitude))
-                    } else {
-                        Toast.makeText(context, "Location not available", Toast.LENGTH_SHORT).show()
-                        onLocationReceived(null)
-                    }
-                }
-                .addOnFailureListener {
-                    Toast.makeText(context, "Failed to retrieve location", Toast.LENGTH_SHORT).show()
-                    onLocationReceived(null)
-                }
-        } else {
-            Toast.makeText(context, "Location permission not granted", Toast.LENGTH_SHORT).show()
+  if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED) {
+    fusedLocationClient
+        .getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
+        .addOnSuccessListener { location: Location? ->
+          // In case the user has not allow its phone to share its location the location will be
+          // latitude and longitude will be null
+          if (location != null) {
+            onLocationReceived(LatLng(location.latitude, location.longitude))
+          } else {
+            Toast.makeText(context, "Location not available", Toast.LENGTH_SHORT).show()
             onLocationReceived(null)
+          }
         }
-    }
-
+        .addOnFailureListener {
+          Toast.makeText(context, "Failed to retrieve location", Toast.LENGTH_SHORT).show()
+          onLocationReceived(null)
+        }
+  } else {
+    Toast.makeText(context, "Location permission was not granted by the user", Toast.LENGTH_SHORT)
+        .show()
+    onLocationReceived(null)
+  }
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.CameraPosition
@@ -17,50 +18,50 @@ fun MapPickerBox(
     lessonTitle: String,
     onLocationSelected: (Pair<Double, Double>) -> Unit
 ) {
-  val EPFLCoordinates = LatLng(46.520374, 6.568339)
+    val EPFLCoordinates = LatLng(46.520374, 6.568339)
 
-  var selectedPosition by remember {
-    mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
-  }
-  val markerState = rememberMarkerState(position = selectedPosition)
+    var selectedPosition by remember {
+        mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
+    }
+    val markerState = rememberMarkerState(position = selectedPosition)
 
-  val cameraPositionState = rememberCameraPositionState {
-    position =
-        if (selectedPosition.latitude == 0.0 && selectedPosition.longitude == 0.0) {
-          CameraPosition.fromLatLngZoom(EPFLCoordinates, 15f)
-        } else {
-          CameraPosition.fromLatLngZoom(selectedPosition, 15f)
-        }
-  }
+    val cameraPositionState = rememberCameraPositionState {
+        position =
+            if (selectedPosition.latitude == 0.0 && selectedPosition.longitude == 0.0) {
+                CameraPosition.fromLatLngZoom(EPFLCoordinates, 15f)
+            } else {
+                CameraPosition.fromLatLngZoom(selectedPosition, 15f)
+            }
+    }
 
-  Column(
-      modifier = Modifier.fillMaxWidth().padding(16.dp),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)) {
         // Map
         Card(
-            modifier = Modifier.fillMaxWidth().aspectRatio(8f / 9f),
+            modifier = Modifier.testTag("map").fillMaxWidth().aspectRatio(8f / 9f),
             shape = MaterialTheme.shapes.large,
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
-              GoogleMap(
-                  modifier = Modifier.fillMaxSize(),
-                  cameraPositionState = cameraPositionState,
-                  onMapClick = { latLng ->
+            GoogleMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraPositionState = cameraPositionState,
+                onMapClick = { latLng ->
                     selectedPosition = latLng
                     markerState.position = selectedPosition
-                  }) {
-                    if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0) {
-                      Marker(state = markerState, title = "Lesson Location")
-                    }
-                  }
+                }) {
+                if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0) {
+                    Marker(state = markerState, title = "Lesson Location")
+                }
             }
+        }
 
         // Helper text
         Text(
             text =
-                if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0)
-                    "Location selected! Tap confirm to use this location."
-                else "Tap anywhere on the map to select a location",
+            if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0)
+                "Location selected! Tap confirm to use this location."
+            else "Tap anywhere on the map to select a location",
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -68,19 +69,19 @@ fun MapPickerBox(
         // Confirm button
         Button(
             onClick = {
-              onLocationSelected(selectedPosition.latitude to selectedPosition.longitude)
+                onLocationSelected(selectedPosition.latitude to selectedPosition.longitude)
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.testTag("confirmLocation").fillMaxWidth(),
             enabled = selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0,
             colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant)) {
-              Icon(
-                  imageVector = Icons.Default.LocationOn,
-                  contentDescription = null,
-                  modifier = Modifier.padding(end = 8.dp))
-              Text("Confirm Location")
-            }
-      }
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+            Icon(
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp))
+            Text("Confirm Location")
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/github/se/project/ui/map/LocationPickerScreen.kt
@@ -18,50 +18,50 @@ fun MapPickerBox(
     lessonTitle: String,
     onLocationSelected: (Pair<Double, Double>) -> Unit
 ) {
-    val EPFLCoordinates = LatLng(46.520374, 6.568339)
+  val EPFLCoordinates = LatLng(46.520374, 6.568339)
 
-    var selectedPosition by remember {
-        mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
-    }
-    val markerState = rememberMarkerState(position = selectedPosition)
+  var selectedPosition by remember {
+    mutableStateOf(LatLng(initialLocation.first, initialLocation.second))
+  }
+  val markerState = rememberMarkerState(position = selectedPosition)
 
-    val cameraPositionState = rememberCameraPositionState {
-        position =
-            if (selectedPosition.latitude == 0.0 && selectedPosition.longitude == 0.0) {
-                CameraPosition.fromLatLngZoom(EPFLCoordinates, 15f)
-            } else {
-                CameraPosition.fromLatLngZoom(selectedPosition, 15f)
-            }
-    }
+  val cameraPositionState = rememberCameraPositionState {
+    position =
+        if (selectedPosition.latitude == 0.0 && selectedPosition.longitude == 0.0) {
+          CameraPosition.fromLatLngZoom(EPFLCoordinates, 15f)
+        } else {
+          CameraPosition.fromLatLngZoom(selectedPosition, 15f)
+        }
+  }
 
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)) {
+  Column(
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(16.dp)) {
         // Map
         Card(
             modifier = Modifier.testTag("map").fillMaxWidth().aspectRatio(8f / 9f),
             shape = MaterialTheme.shapes.large,
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
-            GoogleMap(
-                modifier = Modifier.fillMaxSize(),
-                cameraPositionState = cameraPositionState,
-                onMapClick = { latLng ->
+              GoogleMap(
+                  modifier = Modifier.fillMaxSize(),
+                  cameraPositionState = cameraPositionState,
+                  onMapClick = { latLng ->
                     selectedPosition = latLng
                     markerState.position = selectedPosition
-                }) {
-                if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0) {
-                    Marker(state = markerState, title = "Lesson Location")
-                }
+                  }) {
+                    if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0) {
+                      Marker(state = markerState, title = "Lesson Location")
+                    }
+                  }
             }
-        }
 
         // Helper text
         Text(
             text =
-            if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0)
-                "Location selected! Tap confirm to use this location."
-            else "Tap anywhere on the map to select a location",
+                if (selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0)
+                    "Location selected! Tap confirm to use this location."
+                else "Tap anywhere on the map to select a location",
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -69,19 +69,19 @@ fun MapPickerBox(
         // Confirm button
         Button(
             onClick = {
-                onLocationSelected(selectedPosition.latitude to selectedPosition.longitude)
+              onLocationSelected(selectedPosition.latitude to selectedPosition.longitude)
             },
             modifier = Modifier.testTag("confirmLocation").fillMaxWidth(),
             enabled = selectedPosition.latitude != 0.0 || selectedPosition.longitude != 0.0,
             colors =
-            ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
-                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant)) {
-            Icon(
-                imageVector = Icons.Default.LocationOn,
-                contentDescription = null,
-                modifier = Modifier.padding(end = 8.dp))
-            Text("Confirm Location")
-        }
-    }
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+              Icon(
+                  imageVector = Icons.Default.LocationOn,
+                  contentDescription = null,
+                  modifier = Modifier.padding(end = 8.dp))
+              Text("Confirm Location")
+            }
+      }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ playServicesMaps = "19.0.0"
 googleIdentity= "1.1.1"
 mapsCompose = "4.3.3"
 mapsComposeUtils = "4.3.0"
+maps = "2.5.3"
+location = "21.0.1"
 
 # Networking
 okhttp = "4.12.0"
@@ -119,6 +121,7 @@ mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "location" }
 google-identity = { module="com.google.android.libraries.identity.googleid:googleid", version.ref ="googleIdentity"}
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "androidxCoreKtx" }


### PR DESCRIPTION
## Descritption
This PR solve #103 and introduces the functionality to display the user's current location on the Google Map alongside the existing lesson location marker. The map now dynamically updates its camera position to accommodate both the user's location and the lesson location.

## Changes Made

### User Location Handling
- Added a new var `userLocation` to store the user's current location, which is fetched when location permissions are granted.
- Implemented a location permission handler (`LocationPermissionHandler`) to request and retrieve the user's location using `FusedLocationClient`.
- If permission is granted and the location is available, the user's location is displayed on the map. If the permission is not granted by the user or is not available, only the Lesson's location is dispayed on the map

### Camera Position Adjustment
- The camera position on the map dynamically adjusts to display both the lesson's location and the user's location, ensuring that both are visible within the map's viewport.
- Added a `getCameraPositionForBothLocations` function to calculate bounds for displaying both locations and adjust the zoom level based on the distance between them.
- I prefered to manage these two settings manually myself but we could also use the GoogleMap API to handle them.

### Location Permission Flow
- If the location permission is not granted yet, the app requests permission from the user and proceeds to display the user’s location only if permission is granted.

## New Features
- The map now displays the lesson location (Marker) alongside the user’s current location (if available).
- Camera zoom and position adjust automatically to fit both locations, with zoom levels based on the distance between them.

## Technical Details
- The `LocationPermissionHandler` component requests the necessary location permission (`ACCESS_FINE_LOCATION`) from the user.
- Upon permission grant, the user's current location is fetched using `FusedLocationClient` and represented as a `LatLng` object.
- The `getCameraPositionForBothLocations` function calculates the camera position to center both the user and lesson locations.
- Zoom level adjusts based on the distance between the two locations to ensure an appropriate map view.

## Potential Improvement
- use the GoogleMap API to handle dynamically the zoom level and the center of the camera
- Inform the user in case it allow the app to have access to its location but the user has not activated its position

## Preview:
<img src="https://github.com/user-attachments/assets/dd1c1de3-5442-4a7e-a63d-3cd5d0336ae5" alt="2024-11-11 all" width="300" />

- All requested Lessons available, click on the lesson "Math help"

<img src="https://github.com/user-attachments/assets/30f05c98-dc4c-421b-9ff1-2dd9427ce821" alt="2024-11-11 location request" width="300" />

- OS ask user to share its location with the app


<img src="https://github.com/user-attachments/assets/ea1fe41d-20f3-447d-b98e-1badc445e530" alt="2024-11-11 location request" width="300" />


- The User's location is displayed on the map along the red marker for the lesson's location





