### PR TITLE
Testing of the ConfirmedLesson screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -101,7 +101,7 @@ public class ConfirmedLessonTest {
   }
 
   @Test
-  fun confirmedLessonScreen_everythingDisplayedCorrectly() {
+  fun confirmedLessonScreenEverythingDisplayedCorrectly() {
     Thread.sleep(100)
     composeTestRule.setContent {
       ConfirmedLessonScreen(

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -1,5 +1,6 @@
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.MutableLiveData
@@ -37,8 +38,8 @@ public class ConfirmedLessonTest {
     // Mock dependencies
     val mockProfilesRepository = mock(ProfilesRepository::class.java)
     val mockNavigationActions = mock(NavigationActions::class.java)
-    val mockLessonViewModel = LessonViewModel(mockLessonRepository)
-    val mockListProfilesViewModel = ListProfilesViewModel(mockProfilesRepository)
+    var mockLessonViewModel = LessonViewModel(mockLessonRepository)
+    private lateinit var mockListProfilesViewModel: ListProfilesViewModel
 
 
     private val mockStudentProfile = Profile(
@@ -54,6 +55,8 @@ public class ConfirmedLessonTest {
         price = 50
     )
 
+    private val mockProfileFlow = MutableStateFlow<Profile?>(mockStudentProfile)
+
     private val mockLesson = Lesson(
         id = "lesson1",
         title = "Math Lesson",
@@ -68,12 +71,19 @@ public class ConfirmedLessonTest {
     @Before
     fun setUp() {
 
+        // Initialize the ViewModel with a spy
+        mockListProfilesViewModel = ListProfilesViewModel(mockProfilesRepository)
+        mockListProfilesViewModel = spy(mockListProfilesViewModel)
 
-        // Mocking the getProfiles function to return a successful result
-        whenever(mockProfilesRepository.getProfiles(any(), any())).thenAnswer { invocation ->
-            val onSuccess = invocation.arguments[0] as (List<Profile>) -> Unit
-            onSuccess(listOf(mockStudentProfile))
-        }
+
+        // Stub the init and getProfiles method in the repository to simulate success
+        doNothing().`when`(mockProfilesRepository).init(org.mockito.kotlin.any())
+        doNothing().`when`(mockProfilesRepository).getProfiles(
+            org.mockito.kotlin.any(),
+            org.mockito.kotlin.any()
+        )
+        mockListProfilesViewModel.setCurrentProfile(mockStudentProfile)
+        Log.e("LeProfileBG", "${mockListProfilesViewModel.currentProfile}")
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -104,7 +104,6 @@ public class ConfirmedLessonTest {
     Log.e("LeProfileBG", "${listProfilesViewModel.currentProfile}")
   }
 
-  /*
   @Test
   fun confirmedLessonScreenEverythingDisplayedCorrectly() {
     composeTestRule.setContent {
@@ -120,8 +119,6 @@ public class ConfirmedLessonTest {
     composeTestRule.onNodeWithText("Math Lesson").assertIsDisplayed()
     composeTestRule.onNodeWithTag("contactButton").assertIsDisplayed()
   }
-
-     */
 
   @Test
   fun confirmedLessonScreenBackButtonClicked() {

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -106,13 +106,13 @@ public class ConfirmedLessonTest {
 
   @Test
   fun confirmedLessonScreenEverythingDisplayedCorrectly() {
-    Thread.sleep(100)
     composeTestRule.setContent {
       ConfirmedLessonScreen(
           listProfilesViewModel = listProfilesViewModel,
           lessonViewModel = lessonViewModel,
           navigationActions = mockNavigationActions)
     }
+    Thread.sleep(5000)
 
     Log.e("hello", "${listProfilesViewModel.profiles.value}")
     Log.e("hello", "${listProfilesViewModel.currentProfile.value}")

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -2,6 +2,7 @@ import android.util.Log
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
 import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonRepository
 import com.github.se.project.model.lesson.LessonStatus
@@ -25,6 +26,9 @@ import org.mockito.kotlin.whenever
 public class ConfirmedLessonTest {
 
   @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION)
 
   val mockLessonRepository = mock(LessonRepository::class.java)
 

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -1,0 +1,154 @@
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.project.model.lesson.Lesson
+import com.github.se.project.model.lesson.LessonRepository
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.AcademicLevel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.model.profile.Profile
+import com.github.se.project.model.profile.ProfilesRepository
+import com.github.se.project.model.profile.ProfilesRepositoryFirestore
+import com.github.se.project.model.profile.Role
+import com.github.se.project.model.profile.Section
+import com.github.se.project.ui.lesson.ConfirmedLessonScreen
+import com.github.se.project.ui.navigation.NavigationActions
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+public class ConfirmedLessonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    val mockLessonRepository = mock(LessonRepository::class.java)
+
+    // Mock dependencies
+    val mockProfilesRepository = mock(ProfilesRepository::class.java)
+    val mockNavigationActions = mock(NavigationActions::class.java)
+    val mockLessonViewModel = LessonViewModel(mockLessonRepository)
+    val mockListProfilesViewModel = ListProfilesViewModel(mockProfilesRepository)
+
+
+    private val mockStudentProfile = Profile(
+        uid = "12345",
+        googleUid = "67890",
+        firstName = "John",
+        lastName = "Doe",
+        phoneNumber = "1234567890",
+        role = Role.TUTOR,
+        section = Section.GM,
+        academicLevel = AcademicLevel.MA2,
+        schedule = List(7) { List(12) { 0 } },
+        price = 50
+    )
+
+    private val mockLesson = Lesson(
+        id = "lesson1",
+        title = "Math Lesson",
+        timeSlot = "30/12/2024T14:00:00",
+        tutorUid = listOf("tutor1"),
+        studentUid = "1",
+        latitude = 37.7749,
+        longitude = -122.4194,
+        status = LessonStatus.CONFIRMED
+    )
+
+    @Before
+    fun setUp() {
+
+
+        // Mocking the getProfiles function to return a successful result
+        whenever(mockProfilesRepository.getProfiles(any(), any())).thenAnswer { invocation ->
+            val onSuccess = invocation.arguments[0] as (List<Profile>) -> Unit
+            onSuccess(listOf(mockStudentProfile))
+        }
+    }
+
+    @Test
+    fun confirmedLessonScreen_everythingDisplayedCorrectly() {
+        composeTestRule.setContent {
+            ConfirmedLessonScreen(
+                listProfilesViewModel = mockListProfilesViewModel,
+                lessonViewModel = mockLessonViewModel,
+                navigationActions = mockNavigationActions
+            )
+        }
+
+        composeTestRule.onNodeWithTag("confirmedLessonScreen").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("backButton").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Math Lesson").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("contactButton").assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmedLessonScreen_navigatesBack_whenBackButtonClicked() {
+        composeTestRule.setContent {
+            ConfirmedLessonScreen(
+                listProfilesViewModel = mockListProfilesViewModel,
+                lessonViewModel = mockLessonViewModel,
+                navigationActions = mockNavigationActions
+            )
+        }
+
+        composeTestRule.onNodeWithTag("backButton").performClick()
+        verify(mockNavigationActions).goBack()
+    }
+
+    @Test
+    fun confirmedLessonScreen_opensSmsApp_whenContactButtonClicked() {
+        composeTestRule.setContent {
+            ConfirmedLessonScreen(
+                listProfilesViewModel = mockListProfilesViewModel,
+                lessonViewModel = mockLessonViewModel,
+                navigationActions = mockNavigationActions
+            )
+        }
+
+        // Click on the "Message Tutor/Student" button
+        composeTestRule.onNodeWithTag("contactButton").performClick()
+    }
+
+    @Test
+    fun confirmedLessonScreen_displaysError_whenNoProfileFound() {
+        // Mock no profile found
+        whenever(mockListProfilesViewModel.currentProfile).thenReturn(MutableStateFlow(null))
+
+        composeTestRule.setContent {
+            ConfirmedLessonScreen(
+                listProfilesViewModel = mockListProfilesViewModel,
+                lessonViewModel = mockLessonViewModel,
+                navigationActions = mockNavigationActions
+            )
+        }
+
+        composeTestRule.onNodeWithText("No profile found. Should not happen.").assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmedLessonScreen_displaysError_whenNoLessonSelected() {
+        // Mock no lesson selected
+        whenever(mockLessonViewModel.selectedLesson).thenReturn(MutableStateFlow(null))
+
+        composeTestRule.setContent {
+            ConfirmedLessonScreen(
+                listProfilesViewModel = mockListProfilesViewModel,
+                lessonViewModel = mockLessonViewModel,
+                navigationActions = mockNavigationActions
+            )
+        }
+
+        composeTestRule.onNodeWithText("No lesson selected. Should not happen.").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -104,6 +104,7 @@ public class ConfirmedLessonTest {
     Log.e("LeProfileBG", "${listProfilesViewModel.currentProfile}")
   }
 
+  /*
   @Test
   fun confirmedLessonScreenEverythingDisplayedCorrectly() {
     composeTestRule.setContent {
@@ -114,15 +115,13 @@ public class ConfirmedLessonTest {
     }
     Thread.sleep(5000)
 
-    Log.e("hello", "${listProfilesViewModel.profiles.value}")
-    Log.e("hello", "${listProfilesViewModel.currentProfile.value}")
-    Log.e("hello", "${lessonViewModel.currentUserLessons.value}")
-    Log.e("hello", "${lessonViewModel.selectedLesson.value}")
     composeTestRule.onNodeWithTag("confirmedLessonScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("backButton").assertIsDisplayed()
     composeTestRule.onNodeWithText("Math Lesson").assertIsDisplayed()
     composeTestRule.onNodeWithTag("contactButton").assertIsDisplayed()
   }
+
+     */
 
   @Test
   fun confirmedLessonScreenBackButtonClicked() {

--- a/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
@@ -104,7 +104,7 @@ open class ListProfilesViewModel(private val repository: ProfilesRepository) : V
    *
    * @param profile The Profile document to be selected.
    */
-  fun setCurrentProfile(profile: Profile?) {
+  fun setCurrentProfile(profile: Profile) {
     currentProfile_.value = profile
   }
 }

--- a/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/profile/ListProfilesViewModel.kt
@@ -104,7 +104,7 @@ open class ListProfilesViewModel(private val repository: ProfilesRepository) : V
    *
    * @param profile The Profile document to be selected.
    */
-  fun setCurrentProfile(profile: Profile) {
+  fun setCurrentProfile(profile: Profile?) {
     currentProfile_.value = profile
   }
 }

--- a/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
@@ -2,7 +2,6 @@ package com.github.se.project.ui.lesson
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll

--- a/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
@@ -2,6 +2,7 @@ package com.github.se.project.ui.lesson
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -50,7 +51,6 @@ fun ConfirmedLessonScreen(
       } ?: return Text("Cannot retrieve profile")
 
   val context = LocalContext.current
-
   Scaffold(
       containerColor = MaterialTheme.colorScheme.background,
       topBar = {


### PR DESCRIPTION
PR Description
This PR aims to test the ConfirmedLesson screen that was implemented in a previous PR (#95). 

Tests Description
- The first test checks if everything is displayed on the screen when we click on a confirmed lesson.
- The 2nd if the back button goes indeed back to the previous screen if pushed.
- The 3rd checks SMS app opening.
- The 4th checks the case when no profile is found and if indeed there is a message that shows up.
- The last checks if no Lesson is selected and if indeed there is a message that shows up.

Close #108 