### PR TITLE
Fix CI random error

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -108,7 +108,7 @@ jobs:
           arch: x86_64
           avd-name: github
           force-avd-creation: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
+          emulator-options: -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
           idling-resources: true

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,4 @@
-name: Bootcamp CI - Test Runner
+name: PocketTutor CI - Test Runner
 
 # Run the workflow when commits are pushed on main or when a PR is modified
 on:
@@ -108,10 +108,10 @@ jobs:
           arch: x86_64
           avd-name: github
           force-avd-creation: true
-          emulator-options: -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
           disable-animations: true
+          disable-linux-hw-accel: true
           script: ./gradlew connectedCheck --parallel --build-cache
-          idling-resources: true
 
       # This step generates the coverage report which will be used later in the semester for monitoring purposes
       - name: Generate coverage

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -108,7 +108,7 @@ jobs:
           arch: x86_64
           avd-name: github
           force-avd-creation: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
+          emulator-options: -no-window -gpu off -noaudio -no-boot-anim -camera-back none -skin 1080x1920
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Run instrumentation tests
         # This action assumes that Android sdk is already present in the runner. Which is true for the bootcamp, but won't be for your own project.
         # If you want to use this CI for your project, replace the following line with: uses: reactivecircus/android-emulator-runner@v2
-        uses: reactivecircus/android-emulator-runner@v4
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
           target: google_apis

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - chore/ci-random-error
 
   pull_request:
     types:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -110,7 +110,6 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
           disable-animations: true
-          disable-linux-hw-accel: true
           script: ./gradlew connectedCheck --parallel --build-cache
 
       # This step generates the coverage report which will be used later in the semester for monitoring purposes

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - chore/ci-random-error
 
   pull_request:
     types:
@@ -100,7 +101,7 @@ jobs:
       - name: Run instrumentation tests
         # This action assumes that Android sdk is already present in the runner. Which is true for the bootcamp, but won't be for your own project.
         # If you want to use this CI for your project, replace the following line with: uses: reactivecircus/android-emulator-runner@v2
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v4
         with:
           api-level: 34
           target: google_apis
@@ -110,6 +111,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
+          idling-resources: true
 
       # This step generates the coverage report which will be used later in the semester for monitoring purposes
       - name: Generate coverage

--- a/app/src/androidTest/java/com/github/se/project/ui/endToEnd/StudentEndToEnd.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/endToEnd/StudentEndToEnd.kt
@@ -193,6 +193,7 @@ class EndToEndTest {
     composeTestRule.onNodeWithTag("confirmLocation").performClick()
     composeTestRule.onNodeWithTag("confirmButton").performClick()
 
+    Thread.sleep(5000) // Wait for the tutor matching screen to load
     // Select a tutor
     composeTestRule.onNodeWithTag("tutorCard_0").performClick()
     composeTestRule.onNodeWithText("Confirm").performClick()

--- a/app/src/androidTest/java/com/github/se/project/ui/endToEnd/StudentEndToEnd.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/endToEnd/StudentEndToEnd.kt
@@ -196,6 +196,7 @@ class EndToEndTest {
     Thread.sleep(5000) // Wait for the tutor matching screen to load
     // Select a tutor
     composeTestRule.onNodeWithTag("tutorCard_0").performClick()
+    Thread.sleep(500) // Wait for the dialog to be shown
     composeTestRule.onNodeWithText("Confirm").performClick()
     // composeTestRule.onNodeWithTag("confirmButton").performClick()
     assert(currentLesson!!.title == "End-to-end testing")
@@ -278,7 +279,9 @@ class EndToEndTest {
     composeTestRule.onNodeWithTag("Profile Icon", true).performClick()
     composeTestRule.onNodeWithTag("closeButton").performClick()
     composeTestRule.onNodeWithText("Help how do I write tests").performClick()
+    Thread.sleep(5000) // Wait for the tutor matching screen to load
     composeTestRule.onNodeWithTag("tutorCard_0").performClick()
+    Thread.sleep(500) // Wait for the dialog to be shown
     composeTestRule.onNodeWithText("Confirm").performClick()
 
     // Check if the lesson is updated and displayed

--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/ConfirmedLessonTest.kt
@@ -129,6 +129,7 @@ public class ConfirmedLessonTest {
           navigationActions = mockNavigationActions)
     }
     composeTestRule.waitForIdle()
+    Thread.sleep(5000)
 
     composeTestRule.onNodeWithTag("backButton").performClick()
     verify(mockNavigationActions).goBack()
@@ -142,6 +143,7 @@ public class ConfirmedLessonTest {
           lessonViewModel = lessonViewModel,
           navigationActions = mockNavigationActions)
     }
+    Thread.sleep(5000)
 
     // Click on the "Message Tutor/Student" button
     composeTestRule.onNodeWithTag("contactButton").performClick()
@@ -158,6 +160,7 @@ public class ConfirmedLessonTest {
           lessonViewModel = lessonViewModel,
           navigationActions = mockNavigationActions)
     }
+    Thread.sleep(5000)
 
     composeTestRule.onNodeWithText("No profile found. Should not happen.").assertIsDisplayed()
   }
@@ -173,6 +176,7 @@ public class ConfirmedLessonTest {
           lessonViewModel = lessonViewModel,
           navigationActions = mockNavigationActions)
     }
+    Thread.sleep(5000)
 
     composeTestRule.onNodeWithText("No lesson selected. Should not happen.").assertIsDisplayed()
   }


### PR DESCRIPTION
# Fix a CI error that occured when running instrumentation test

### PR Description
This PR tries to solve teh CI bugs that we experiment with out instrumentation test. The bugs was the followings :

	androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non default root matcher, it may be picking a root that never takes focus. Root:
	Root{application-window-token=android.view.ViewRootImpl$W@2ed9722, window-token=android.view.ViewRootImpl$W@2ed9722, has-window-focus=false, layout-params-type=1, layout-params-string={(0,0)(fillxfill) sim={forwardNavigation} ty=BASE_APPLICATION wanim=0x10302fe

	java.lang.IllegalStateException: No compose hierarchies found in the app. Possible reasons include: (1) the Activity that calls setContent did not launch; (2) setContent was not called; (3) setContent was called before the ComposeTestRule ran. If setContent is called by the Activity, make sure the Activity is launched after the ComposeTestRule runs

The fix that seems to work for now is to avoid using GPU accelation process.