### PR TITLE
Implement Lesson Cancellation logic for student and tutor

### DIFF
--- a/app/src/androidTest/java/com/github/se/project/ui/lesson/TutorMatchingTest.kt
+++ b/app/src/androidTest/java/com/github/se/project/ui/lesson/TutorMatchingTest.kt
@@ -113,6 +113,7 @@ class TutorMatchingScreenTest {
 
     // Stub navigation actions
     doNothing().`when`(navigationActions).navigateTo(anyString())
+    doNothing().`when`(navigationActions).goBack()
 
     // Mock flow properties on ViewModels
     whenever(listProfilesViewModel.currentProfile).thenReturn(profileFlow)
@@ -210,13 +211,69 @@ class TutorMatchingScreenTest {
   }
 
   @Test
-  fun confirmButtonNotDisplayed_whenStatusIsNotMatching() {
+  fun correctButtonAreDisplayed_whenStatusIsStudentRequested() {
     lessonFlow.value = lessonFlow.value.copy(status = LessonStatus.STUDENT_REQUESTED)
 
     composeTestRule.setContent {
       TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
     }
 
-    composeTestRule.onNodeWithTag("confirmButton").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("noTutorButton").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("cancellationButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun lessonCancellationDialogIsDisplayed_whenCancellationButtonClicked() {
+    lessonFlow.value = lessonFlow.value.copy(status = LessonStatus.STUDENT_REQUESTED)
+
+    composeTestRule.setContent {
+      TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("cancellationButton").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("cancellationDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cancellationDialogTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cancellationDialogText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cancellationDialogConfirmButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cancellationDialogDismissButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun lessonDeleted_whenCancellationDialogConfirmed() {
+    lessonFlow.value = lessonFlow.value.copy(status = LessonStatus.STUDENT_REQUESTED)
+
+    composeTestRule.setContent {
+      TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Click on the cancellation button and confirm the dialog
+    composeTestRule.onNodeWithTag("cancellationButton").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("cancellationDialogConfirmButton")
+        .assertIsDisplayed()
+        .performClick()
+
+    // Verify the dialog is dismissed and the navigation is done
+    composeTestRule.onNodeWithTag("cancellationDialog").assertIsNotDisplayed()
+    verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun dialogDismissed_whenCancellationDialogDismissed() {
+    lessonFlow.value = lessonFlow.value.copy(status = LessonStatus.STUDENT_REQUESTED)
+
+    composeTestRule.setContent {
+      TutorMatchingScreen(listProfilesViewModel, lessonViewModel, navigationActions)
+    }
+
+    // Click on the cancellation button and dismiss the dialog
+    composeTestRule.onNodeWithTag("cancellationButton").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("cancellationDialogDismissButton")
+        .assertIsDisplayed()
+        .performClick()
+
+    // Verify the dialog was dismissed
+    composeTestRule.onNodeWithTag("cancellationDialog").assertIsNotDisplayed()
   }
 }

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonStatus.kt
@@ -6,7 +6,8 @@ enum class LessonStatus {
   PENDING_TUTOR_CONFIRMATION,
   CONFIRMED, // Lesson has been confirmed by both student and tutor
   COMPLETED,
-  CANCELLED, // Lesson has been canceled by either student or tutor,
+  STUDENT_CANCELLED, // Lesson has been canceled by student
+  TUTOR_CANCELLED, // Lesson has been canceled by tutor
   MATCHING, // Matching is processed
   INSTANT_REQUESTED, // Instant lesson requested by student
   INSTANT_CONFIRMED, // Instant lesson confirmed by tutor

--- a/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
+++ b/app/src/main/java/com/github/se/project/model/lesson/LessonViewModel.kt
@@ -21,6 +21,9 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
   private val _currentUserLessons = MutableStateFlow<List<Lesson>>(emptyList())
   open val currentUserLessons: StateFlow<List<Lesson>> = _currentUserLessons.asStateFlow()
 
+  private val _cancelledLessons = MutableStateFlow<List<Lesson>>(emptyList())
+  open val cancelledLessons: StateFlow<List<Lesson>> = _cancelledLessons.asStateFlow()
+
   private val _selectedLesson = MutableStateFlow<Lesson?>(null)
   open val selectedLesson: StateFlow<Lesson?> = _selectedLesson.asStateFlow()
 
@@ -137,6 +140,14 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
                   else -> false
                 }
               }
+          _cancelledLessons.value =
+              fetchedLessons.filter { lesson ->
+                when (lesson.status) {
+                  LessonStatus.STUDENT_CANCELLED -> true
+                  LessonStatus.TUTOR_CANCELLED -> false
+                  else -> false
+                }
+              }
           onComplete()
         },
         onFailure = {
@@ -156,6 +167,14 @@ open class LessonViewModel(private val repository: LessonRepository) : ViewModel
         studentUid = studentUid,
         onSuccess = { fetchedLessons ->
           _currentUserLessons.value = fetchedLessons
+          _cancelledLessons.value =
+              fetchedLessons.filter { lesson ->
+                when (lesson.status) {
+                  LessonStatus.STUDENT_CANCELLED -> false
+                  LessonStatus.TUTOR_CANCELLED -> true
+                  else -> false
+                }
+              }
           onComplete() // Call the provided callback on success
         },
         onFailure = {

--- a/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/DisplayLessons.kt
@@ -14,7 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -36,7 +36,6 @@ import com.github.se.project.model.lesson.Lesson
 import com.github.se.project.model.lesson.LessonStatus
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.model.profile.Profile
-import com.github.se.project.ui.components.LessonColors.getLessonColor
 import com.github.se.project.utils.SuitabilityScoreCalculator
 import com.github.se.project.utils.formatDate
 
@@ -96,7 +95,8 @@ object LessonColors {
           }
       status == LessonStatus.INSTANT_CONFIRMED ->
           if (isDarkTheme) DarkInstantConfirmed else LightInstantConfirmed
-      status == LessonStatus.CANCELLED -> if (isDarkTheme) DarkCancelled else LightCancelled
+      status == LessonStatus.STUDENT_CANCELLED -> if (isDarkTheme) DarkCancelled else LightCancelled
+      status == LessonStatus.TUTOR_CANCELLED -> if (isDarkTheme) DarkCancelled else LightCancelled
       else -> MaterialTheme.colorScheme.surface
     }
   }
@@ -217,7 +217,7 @@ fun DisplayLessons(
                   if (lesson.status == LessonStatus.COMPLETED ||
                       lesson.status == LessonStatus.CONFIRMED ||
                       lesson.status == LessonStatus.INSTANT_CONFIRMED) {
-                    Divider(
+                    HorizontalDivider(
                         modifier = Modifier.padding(vertical = 4.dp),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
 

--- a/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
+++ b/app/src/main/java/com/github/se/project/ui/components/LessonEditor.kt
@@ -56,7 +56,6 @@ import com.github.se.project.model.profile.Profile
 import com.github.se.project.model.profile.Subject
 import com.github.se.project.ui.map.LocationPermissionHandler
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.rememberCameraPositionState
 import java.util.Calendar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -95,8 +94,6 @@ fun LessonEditor(
   var userLocation by remember { mutableStateOf<LatLng?>(null) }
   var isLocationChecked by remember { mutableStateOf(false) }
 
-  val cameraPositionState = rememberCameraPositionState {}
-
   var showMapDialog by remember { mutableStateOf(false) }
 
   if (currentLessonId.value != lesson?.id) {
@@ -128,7 +125,9 @@ fun LessonEditor(
           { _, year, month, dayOfMonth ->
             val selectedCalendar = Calendar.getInstance()
             selectedCalendar.set(year, month, dayOfMonth)
-            selectedDate = "$dayOfMonth/${month + 1}/$year"
+            val stringDay = dayOfMonth.toString().padStart(2, '0')
+            val stringMonth = (month + 1).toString().padStart(2, '0')
+            selectedDate = "$stringDay/$stringMonth/$year"
           },
           calendar.get(Calendar.YEAR),
           calendar.get(Calendar.MONTH),
@@ -488,8 +487,8 @@ fun validateLessonInput(
 }
 
 fun isInstant(lesson: Lesson?): Boolean {
-  return (lesson?.status == LessonStatus.INSTANT_REQUESTED) ?: false ||
-      (lesson?.status == LessonStatus.INSTANT_CONFIRMED) ?: false
+  return (lesson?.status == LessonStatus.INSTANT_REQUESTED) ||
+      (lesson?.status == LessonStatus.INSTANT_CONFIRMED)
 }
 
 fun isInstant(timeSlot: String): Boolean {

--- a/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/ConfirmedLesson.kt
@@ -2,21 +2,45 @@ package com.github.se.project.ui.lesson
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.layout.*
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Send
-import androidx.compose.material3.*
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.project.model.lesson.LessonStatus
 import com.github.se.project.model.lesson.LessonViewModel
 import com.github.se.project.model.profile.ListProfilesViewModel
 import com.github.se.project.model.profile.Role
@@ -24,6 +48,9 @@ import com.github.se.project.ui.components.DisplayLessonDetails
 import com.github.se.project.ui.components.LessonLocationDisplay
 import com.github.se.project.ui.navigation.NavigationActions
 import com.github.se.project.utils.formatDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,6 +76,9 @@ fun ConfirmedLessonScreen(
       } ?: return Text("Cannot retrieve profile")
 
   val context = LocalContext.current
+
+  var showCancelDialog by remember { mutableStateOf(false) }
+
   Scaffold(
       containerColor = MaterialTheme.colorScheme.background,
       topBar = {
@@ -63,7 +93,15 @@ fun ConfirmedLessonScreen(
                   }
             },
             title = {
-              Text(text = "Confirmed Lesson", style = MaterialTheme.typography.titleLarge)
+              Text(
+                  text =
+                      when (lesson.status) {
+                        LessonStatus.CONFIRMED -> "Confirmed Lesson"
+                        LessonStatus.PENDING_TUTOR_CONFIRMATION -> "Pending Lesson"
+                        LessonStatus.STUDENT_REQUESTED -> "Requested Lesson"
+                        else -> "Lesson Details"
+                      },
+                  style = MaterialTheme.typography.titleLarge)
             })
       }) { paddingValues ->
         Column(
@@ -94,29 +132,153 @@ fun ConfirmedLessonScreen(
 
               Spacer(modifier = Modifier.weight(1f))
 
-              // This button require a context when testing
-              // Contact Button
-              Button(
-                  shape = MaterialTheme.shapes.medium,
-                  onClick = {
-                    val intent =
-                        Intent(Intent.ACTION_VIEW).apply {
-                          data = Uri.parse("sms:${otherProfile.phoneNumber}")
-                          putExtra(
-                              "sms_body",
-                              "Hello, about our lesson ${formatDate(lesson.timeSlot)}...")
-                        }
-                    context.startActivity(intent)
-                  },
-                  modifier =
-                      Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("contactButton")) {
-                    Icon(
-                        Icons.Default.Send,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp))
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Message ${if (isStudent) "Tutor" else "Student"}")
-                  }
+              if (lesson.status == LessonStatus.CONFIRMED) {
+                // This button require a context when testing
+                // Contact Button
+                Button(
+                    shape = MaterialTheme.shapes.medium,
+                    onClick = {
+                      val intent =
+                          Intent(Intent.ACTION_VIEW).apply {
+                            data = Uri.parse("sms:${otherProfile.phoneNumber}")
+                            putExtra(
+                                "sms_body",
+                                "Hello, about our lesson ${formatDate(lesson.timeSlot)}...")
+                          }
+                      context.startActivity(intent)
+                    },
+                    modifier =
+                        Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("contactButton")) {
+                      Icon(
+                          Icons.AutoMirrored.Filled.Send,
+                          contentDescription = null,
+                          modifier = Modifier.size(20.dp))
+                      Spacer(modifier = Modifier.width(8.dp))
+                      Text("Message ${if (isStudent) "Tutor" else "Student"}")
+                    }
+              }
+
+              if (lesson.status == LessonStatus.CONFIRMED ||
+                  (lesson.status == LessonStatus.STUDENT_REQUESTED &&
+                      currentProfile.role == Role.TUTOR) ||
+                  (lesson.status == LessonStatus.PENDING_TUTOR_CONFIRMATION &&
+                      currentProfile.role == Role.STUDENT)) {
+                // Cancellation Button
+                Button(
+                    shape = MaterialTheme.shapes.medium,
+                    onClick = { showCancelDialog = true },
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(bottom = 16.dp)
+                            .testTag("cancellationButton"),
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error)) {
+                      Icon(
+                          Icons.Default.Close,
+                          contentDescription = null,
+                          modifier = Modifier.size(20.dp))
+                      Spacer(modifier = Modifier.width(8.dp))
+                      Text("Cancel the Lesson")
+                    }
+              }
             }
+
+        if (showCancelDialog) {
+          AlertDialog(
+              modifier = Modifier.testTag("cancelDialog"),
+              onDismissRequest = { showCancelDialog = false },
+              title = {
+                Text(text = "Lesson Cancellation", modifier = Modifier.testTag("cancelDialogTitle"))
+              },
+              text = {
+                Text(
+                    text =
+                        if (lesson.status == LessonStatus.CONFIRMED ||
+                            (lesson.status == LessonStatus.PENDING_TUTOR_CONFIRMATION &&
+                                currentProfile.role == Role.STUDENT))
+                            "Are you sure you want to cancel the lesson? This action can not be undone."
+                        else if (lesson.status == LessonStatus.STUDENT_REQUESTED &&
+                            currentProfile.role == Role.TUTOR)
+                            "Are you sure you want to cancel your proposition for the lesson?"
+                        else "Should not happen.",
+                    modifier = Modifier.testTag("cancelDialogText"))
+              },
+              confirmButton = {
+                Button(
+                    modifier = Modifier.testTag("cancelDialogConfirmButton"),
+                    onClick = {
+                      if (lesson.status == LessonStatus.CONFIRMED) {
+                        // If the lesson is within 24 hours, do not allow cancellation
+                        // Otherwise, update the lesson status and refresh the list of lessons
+                        if (isCancellationValid(lesson.timeSlot)) {
+                          if (isStudent) {
+                            lessonViewModel.updateLesson(
+                                lesson = lesson.copy(status = LessonStatus.STUDENT_CANCELLED),
+                                onComplete = {
+                                  lessonViewModel.getLessonsForStudent(currentProfile.uid)
+                                })
+                          } else {
+                            lessonViewModel.updateLesson(
+                                lesson = lesson.copy(status = LessonStatus.TUTOR_CANCELLED),
+                                onComplete = {
+                                  lessonViewModel.getLessonsForTutor(currentProfile.uid)
+                                })
+                          }
+                        } else {
+                          Toast.makeText(
+                                  context,
+                                  "You can only cancel a lesson 24 hours before it starts",
+                                  Toast.LENGTH_LONG)
+                              .show()
+                          showCancelDialog = false
+                        }
+                      } else if (lesson.status == LessonStatus.STUDENT_REQUESTED &&
+                          currentProfile.role == Role.TUTOR) {
+                        // Remove the tutor from the lesson tutor list and refresh the list of
+                        // lessons
+                        lessonViewModel.updateLesson(
+                            lesson =
+                                lesson.copy(tutorUid = lesson.tutorUid.minus(currentProfile.uid)),
+                            onComplete = { lessonViewModel.getLessonsForTutor(currentProfile.uid) })
+                      } else if (lesson.status == LessonStatus.PENDING_TUTOR_CONFIRMATION &&
+                          currentProfile.role == Role.STUDENT) {
+                        // Delete the lesson and refresh the list of lessons
+                        lessonViewModel.deleteLesson(
+                            lesson.id,
+                            onComplete = {
+                              lessonViewModel.getLessonsForStudent(currentProfile.uid)
+                            })
+                      }
+                      showCancelDialog = false
+                      navigationActions.goBack()
+                    }) {
+                      Text("Yes, cancel it")
+                    }
+              },
+              dismissButton = {
+                Button(
+                    modifier = Modifier.testTag("cancelDialogDismissButton"),
+                    onClick = { showCancelDialog = false }) {
+                      Text("No")
+                    }
+              })
+        }
       }
+}
+
+/**
+ * Checks if the time slot of the lesson is valid for cancellation. The lesson can be cancelled if
+ * it is more than 24 hours away.
+ *
+ * @param timeSlot The time slot of the lesson.
+ * @return True if the lesson can be cancelled, false otherwise.
+ */
+private fun isCancellationValid(timeSlot: String): Boolean {
+  val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy'T'HH:mm:ss")
+  val lessonDateTime = LocalDateTime.parse(timeSlot, formatter)
+  val currentDateTime = LocalDateTime.now()
+  val currentDateTimePlus24Hours = currentDateTime.plus(24, ChronoUnit.HOURS)
+
+  return lessonDateTime.isAfter(currentDateTimePlus24Hours)
 }

--- a/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
+++ b/app/src/main/java/com/github/se/project/ui/lesson/TutorMatching.kt
@@ -2,13 +2,19 @@ package com.github.se.project.ui.lesson
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -19,7 +25,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -77,6 +85,8 @@ fun TutorMatchingScreen(
 
   val context = LocalContext.current
 
+  var showCancelDialog by remember { mutableStateOf(false) }
+
   Scaffold(
       topBar = {
         TopAppBar(
@@ -119,8 +129,21 @@ fun TutorMatchingScreen(
                 navigationActions.navigateTo(Screen.HOME)
               }) {
                 Text(
-                    "Ask other tutor for your lesson",
+                    "Ask other tutors for your lesson",
                     modifier = Modifier.testTag("noTutorButtonText"))
+              }
+        } else if (currentLesson.status == LessonStatus.STUDENT_REQUESTED) {
+          // Cancellation Button
+          Button(
+              shape = MaterialTheme.shapes.medium,
+              onClick = { showCancelDialog = true },
+              modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("cancellationButton"),
+              colors =
+                  ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)) {
+                Icon(
+                    Icons.Default.Close, contentDescription = null, modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Cancel the Lesson")
               }
         }
       }) { innerPadding ->
@@ -146,6 +169,44 @@ fun TutorMatchingScreen(
                   navigationActions.navigateTo(Screen.SELECTED_TUTOR_DETAILS)
                 })
           }
+        }
+
+        // Cancellation Dialog
+        if (showCancelDialog) {
+          AlertDialog(
+              modifier = Modifier.testTag("cancellationDialog"),
+              onDismissRequest = { showCancelDialog = false },
+              title = {
+                Text(
+                    text = "Lesson Cancellation",
+                    modifier = Modifier.testTag("cancellationDialogTitle"))
+              },
+              text = {
+                Text(
+                    text =
+                        "Are you sure you want to cancel the lesson? This action can not be undone.",
+                    modifier = Modifier.testTag("cancellationDialogText"))
+              },
+              confirmButton = {
+                Button(
+                    modifier = Modifier.testTag("cancellationDialogConfirmButton"),
+                    onClick = {
+                      lessonViewModel.deleteLesson(
+                          currentLesson.id,
+                          onComplete = { lessonViewModel.getLessonsForStudent(currentProfile.uid) })
+                      showCancelDialog = false
+                      navigationActions.goBack()
+                    }) {
+                      Text("Yes, cancel it")
+                    }
+              },
+              dismissButton = {
+                Button(
+                    modifier = Modifier.testTag("cancellationDialogDismissButton"),
+                    onClick = { showCancelDialog = false }) {
+                      Text("No")
+                    }
+              })
         }
       }
 }

--- a/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/project/ui/overview/Overview.kt
@@ -9,17 +9,48 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -30,11 +61,21 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.project.R
-import com.github.se.project.model.lesson.*
-import com.github.se.project.model.profile.*
+import com.github.se.project.model.lesson.Lesson
+import com.github.se.project.model.lesson.LessonStatus
+import com.github.se.project.model.lesson.LessonViewModel
+import com.github.se.project.model.profile.ListProfilesViewModel
+import com.github.se.project.model.profile.Profile
+import com.github.se.project.model.profile.Role
 import com.github.se.project.ui.components.DisplayLessons
 import com.github.se.project.ui.components.isInstant
-import com.github.se.project.ui.navigation.*
+import com.github.se.project.ui.navigation.BottomNavigationMenu
+import com.github.se.project.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS_STUDENT
+import com.github.se.project.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS_TUTOR
+import com.github.se.project.ui.navigation.NavigationActions
+import com.github.se.project.ui.navigation.Screen
+import com.github.se.project.ui.navigation.TopLevelDestinations
+import com.github.se.project.utils.formatDate
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -48,6 +89,7 @@ fun HomeScreen(
   val context = LocalContext.current
   val currentProfile = listProfileViewModel.currentProfile.collectAsState().value
   val lessons = lessonViewModel.currentUserLessons.collectAsState().value
+  val cancelledLessons = lessonViewModel.cancelledLessons.collectAsState().value
 
   // Fetch lessons based on the role
   when (currentProfile?.role) {
@@ -66,30 +108,50 @@ fun HomeScreen(
 
   val onLessonClick = { lesson: Lesson ->
     if (currentProfile?.role == Role.STUDENT) {
-      if (lesson.status == LessonStatus.STUDENT_REQUESTED && lesson.tutorUid.isNotEmpty()) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.TUTOR_MATCH)
-      } else if (lesson.status == LessonStatus.STUDENT_REQUESTED) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
-      } else if (lesson.status == LessonStatus.CONFIRMED ||
-          lesson.status == LessonStatus.INSTANT_CONFIRMED) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
-      } else if (lesson.status == LessonStatus.INSTANT_REQUESTED) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
+      when (lesson.status) {
+        LessonStatus.STUDENT_REQUESTED -> {
+          if (lesson.tutorUid.isNotEmpty()) { // "Waiting for your confirmation" section
+            lessonViewModel.selectLesson(lesson)
+            navigationActions.navigateTo(Screen.TUTOR_MATCH)
+          } else { // "Waiting for a Tutor proposal" section
+            lessonViewModel.selectLesson(lesson)
+            navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
+          }
+        }
+        LessonStatus.CONFIRMED,
+        LessonStatus.INSTANT_CONFIRMED -> { // "Upcoming Lessons" section
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+        }
+        LessonStatus.INSTANT_REQUESTED -> { // "Pending instant Lesson" section
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.EDIT_REQUESTED_LESSON)
+        }
+        LessonStatus.PENDING_TUTOR_CONFIRMATION -> { // "Waiting for the Tutor Confirmation" section
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+        }
+        else -> {}
       }
     } else {
-      if (lesson.status == LessonStatus.PENDING_TUTOR_CONFIRMATION) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.TUTOR_LESSON_RESPONSE)
-      } else if (lesson.status == LessonStatus.CONFIRMED) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
-      } else if (lesson.status == LessonStatus.INSTANT_CONFIRMED) {
-        lessonViewModel.selectLesson(lesson)
-        navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+      when (lesson.status) {
+        LessonStatus.PENDING_TUTOR_CONFIRMATION -> {
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.TUTOR_LESSON_RESPONSE)
+        }
+        LessonStatus.STUDENT_REQUESTED -> {
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+        }
+        LessonStatus.CONFIRMED -> {
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+        }
+        LessonStatus.INSTANT_CONFIRMED -> {
+          lessonViewModel.selectLesson(lesson)
+          navigationActions.navigateTo(Screen.CONFIRMED_LESSON)
+        }
+        else -> {}
       }
     }
   }
@@ -124,16 +186,24 @@ fun HomeScreen(
             selectedItem = navigationActions.currentRoute())
       }) { paddingValues ->
         currentProfile?.let { profile ->
-          if (lessons.any { it.status != LessonStatus.COMPLETED }) {
-            LessonsContent(
+          if (cancelledLessons.isNotEmpty()) {
+            CancellationAlerts(
                 profile = profile,
-                lessons = lessons,
-                onClick = onLessonClick,
-                paddingValues = paddingValues,
+                lessons = cancelledLessons,
                 listProfilesViewModel = listProfileViewModel,
                 lessonViewModel = lessonViewModel)
           } else {
-            EmptyLessonsState(paddingValues, lessonViewModel, profile)
+            if (lessons.any { it.status != LessonStatus.COMPLETED }) {
+              LessonsContent(
+                  profile = profile,
+                  lessons = lessons,
+                  onClick = onLessonClick,
+                  paddingValues = paddingValues,
+                  listProfilesViewModel = listProfileViewModel,
+                  lessonViewModel = lessonViewModel)
+            } else {
+              EmptyLessonsState(paddingValues, lessonViewModel, profile)
+            }
           }
         } ?: NoProfileFoundScreen(context, navigationActions)
       }
@@ -348,7 +418,7 @@ private fun ExpandableLessonSection(
                       IconButton(onClick = { expanded = !expanded }) {
                         Icon(
                             if (expanded) Icons.Default.KeyboardArrowDown
-                            else Icons.Default.KeyboardArrowLeft,
+                            else Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                             contentDescription = if (expanded) "Collapse" else "Expand")
                       }
                     }
@@ -454,3 +524,69 @@ private data class SectionInfo(
     val icon: ImageVector,
     val tutorEmpty: Boolean = false
 )
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CancellationAlerts(
+    profile: Profile,
+    lessons: List<Lesson>,
+    listProfilesViewModel: ListProfilesViewModel,
+    lessonViewModel: LessonViewModel
+) {
+  lessons.forEach { lesson ->
+    val isTutor = profile.role == Role.TUTOR
+
+    val tutor =
+        if (isTutor) profile
+        else
+            listProfilesViewModel.getProfileById(lesson.tutorUid.first())
+                ?: return Text("Tutor not found")
+
+    val student =
+        if (isTutor)
+            listProfilesViewModel.getProfileById(lesson.studentUid)
+                ?: return Text("Student not found")
+        else profile
+
+    var showCancelDialog = true // Show the alert dialog
+
+    if (showCancelDialog) {
+      AlertDialog(
+          modifier = Modifier.testTag("cancelledLessonDialog"),
+          onDismissRequest = { showCancelDialog = false },
+          title = {
+            Text(
+                text = "Lesson Cancelled by the ${if (isTutor) "Student" else "Tutor"}",
+                modifier = Modifier.testTag("cancelledLessonDialogTitle"))
+          },
+          text = {
+            Text(
+                text =
+                    if (isTutor)
+                        "Be careful! Your lesson with ${student.firstName} ${student.lastName} has been cancelled. It was programmed for ${formatDate(lesson.timeSlot)}."
+                    else
+                        "Be careful! Your lesson with ${tutor.firstName} ${tutor.lastName} has been cancelled. It was programmed for ${formatDate(lesson.timeSlot)}.",
+                modifier = Modifier.testTag("cancelledLessonDialogText"))
+          },
+          confirmButton = {
+            Button(
+                modifier = Modifier.testTag("cancelledLessonDialogConfirmButton"),
+                onClick = {
+                  lessonViewModel.deleteLesson(
+                      lessonId = lesson.id,
+                      onComplete = {
+                        if (isTutor)
+                            lessonViewModel.getLessonsForTutor(
+                                tutor.uid, { showCancelDialog = false })
+                        else
+                            lessonViewModel.getLessonsForStudent(
+                                student.uid, { showCancelDialog = false })
+                      })
+                }) {
+                  Text("OK")
+                }
+          },
+      )
+    }
+  }
+}

--- a/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
+++ b/app/src/test/java/com/github/se/project/model/lesson/LessonViewModelTest.kt
@@ -34,6 +34,38 @@ class LessonViewModelTest {
           latitude = 0.0,
           longitude = 0.0)
 
+  private val tutorCancelledLesson =
+      Lesson(
+          id = "2",
+          title = "Physics Tutoring",
+          description = "Mechanics and Thermodynamics",
+          subject = Subject.PHYSICS,
+          languages = listOf(Language.ENGLISH),
+          tutorUid = listOf("tutor123"),
+          studentUid = "student123",
+          minPrice = 20.0,
+          maxPrice = 40.0,
+          timeSlot = "2024-10-10T10:00:00",
+          status = LessonStatus.TUTOR_CANCELLED,
+          latitude = 0.0,
+          longitude = 0.0)
+
+  private val studentCancelledLesson =
+      Lesson(
+          id = "2",
+          title = "Physics Tutoring",
+          description = "Mechanics and Thermodynamics",
+          subject = Subject.PHYSICS,
+          languages = listOf(Language.ENGLISH),
+          tutorUid = listOf("tutor123"),
+          studentUid = "student123",
+          minPrice = 20.0,
+          maxPrice = 40.0,
+          timeSlot = "2024-10-10T10:00:00",
+          status = LessonStatus.STUDENT_CANCELLED,
+          latitude = 0.0,
+          longitude = 0.0)
+
   @Before
   fun setUp() {
     lessonRepository = mock(LessonRepository::class.java)
@@ -90,6 +122,19 @@ class LessonViewModelTest {
   }
 
   @Test
+  fun getLessonsForTutorUpdatesCancelledLessonStateFlow() = runBlocking {
+    val lessons = listOf(studentCancelledLesson, tutorCancelledLesson)
+    val onSuccessCaptor = argumentCaptor<(List<Lesson>) -> Unit>()
+
+    lessonViewModel.getLessonsForTutor("tutor123") {}
+    verify(lessonRepository).getLessonsForTutor(eq("tutor123"), onSuccessCaptor.capture(), any())
+    onSuccessCaptor.firstValue.invoke(lessons)
+
+    val collectedLessons = lessonViewModel.cancelledLessons.value
+    assertThat(collectedLessons, `is`(listOf(studentCancelledLesson)))
+  }
+
+  @Test
   fun getLessonsForStudentUpdatesStateFlow() = runBlocking {
     val lessons = listOf(lesson)
     val onSuccessCaptor = argumentCaptor<(List<Lesson>) -> Unit>()
@@ -101,5 +146,19 @@ class LessonViewModelTest {
 
     val collectedLessons = lessonViewModel.currentUserLessons.value
     assertThat(collectedLessons, `is`(lessons))
+  }
+
+  @Test
+  fun getLessonsForStudentUpdatesCancelledLessonsStateFlow() = runBlocking {
+    val lessons = listOf(studentCancelledLesson, tutorCancelledLesson)
+    val onSuccessCaptor = argumentCaptor<(List<Lesson>) -> Unit>()
+
+    lessonViewModel.getLessonsForStudent("student123") {}
+    verify(lessonRepository)
+        .getLessonsForStudent(eq("student123"), onSuccessCaptor.capture(), any())
+    onSuccessCaptor.firstValue.invoke(lessons)
+
+    val collectedLessons = lessonViewModel.cancelledLessons.value
+    assertThat(collectedLessons, `is`(listOf(tutorCancelledLesson)))
   }
 }


### PR DESCRIPTION
# Implement cancellation of lessons for all lessons status

### PR Description
In this PR, I have added all the ways a tutor or a student have to cancel a lesson depending on the state of the lesson. I have also included tests for the cancel logic I implemented and a small bug fix concerning the string timeslot used in the lessons.

**Note:** An important thing to note is that when the lesson is confirmed, no users can cancel the lesson less that 24 hours in advance. If he really want to cancel the lesson, we assume that he will contact the other user directly to discuss of a compensation for the cancellation. Since we do not handle the payement in the app, we can not really play a role in this step.

#### Cancellation Logic
At the end of this paragraph, you can see a graph based on the lesson status diagram that show the logic I implemented. I will explained more in details now, by treating each lesson state separately.

- First, concerning the **MATCHING** status, there is no cancellation to implement since the lesson is not completely created (and so not stored in database)
- Secondly, for the **PENDING_TUTOR_CONFIRMATION** state, even if the lesson is associated to a student and a tutor, only the student is actively involved in the lesson so if he want to cancel it, it will directly be deleted from the database.
- Then, in the **STUDENT_REQUESTED** state, both tutor and student can cancelled the lesson. Note that if the tutor has a lesson in that state, it means that he proposed itself for the lesson but that the student has not confirmed yet, so if the tutor cancels his offer, the tutor will simply be removed from the list. Moreover, if the student cancel the lesson, since he has not completely aggreed with any other tutor, the lesson is directly deleted.
- Last but not least, in the **CONFIRMED** state, the logic is a bit more complex since both student and tutor agreed to give the lesson. When a student or a tutor cancells the lesson, the lesson state is changed to CANCELLED and the next time the other user will open his overview, he will get an alert that signal him that the lessons have beend cancelled. After that, when both users have "acknowledge" the cancellation, the lesson is deleted. For example, if a student cancels a lesson, the tutor will receive an alert the next time he will open the overview.

This logic allow us to cancel a lesson at all stage of its life cycle, both if we are a student or a tutor, and with notifcations for persons who are involved in the lesson.

![image](https://github.com/user-attachments/assets/512f2deb-8ebb-4e48-98fb-022e038192b1)

#### Timeslot String Bug Fix
I found a bug in the implementation of the LessonEditor composable, when it saves the timeslot of the lesson. Indeed, when we had a date with only one digit it was not saved into the good format and so could not be parsed correctly. For example, December the 6th was saved as 6/12/24T16:00 but the expected pattern is dd/mm/yyyyThh:mm. I fixed that by adding padding to the date and the month so that it always have 2 charcaters.


### Technical Details
To implement this cancellation logic, I added two status for the CANCELLED lessons: STUDENT_CANCELLED, used when a student cancels the lesson, and TUTOR_CANCELLED, used when a tutor cancels the lessons. I tried to use only one status for both case but I had issue to display the alert only to the users that did not ask for the cancellation. Adding two separate status was the simplest way I found to be able to do so.


In addition, I made modification to the LessonViewModel to add a field that hold the cancelled lesson of the current profile. This mutable state flow is updated with the correct lesson each time we call getLessonsForStudent(...) or getLessonsForTutor(...), this is useful so that the list is refresh regularly when we use the application.


In order for users to cancels their lesson, I updated the ConfirmedLesson and TutorMatching screen to add a cancellation button (display in red) which lead to a dialog used to confirm the cancellation of the lesson. I also reused these two screens to be able to click on all lessons on the overview. I will detailed  is an overview of what screen the user will be moved to when he click on a lesson from the overview.

From the student side:
- "Waiting for your confirmation" section => this was redirected to the TutorMatching screen where I added the cancellation button
- "Waiting for the Tutor Confirmation" section => lessons were not clickable so I made them clickable. We are now redirected to the ConfirmedLesson screen with no possibility to update the lesson but with the possibility to cancel it
- "Waiting for a Tutor proposal" section => I did not change this section since it was already redirected to the EditLesson screen with the possibility to delete the lesson
- "Upcoming lessons" section => it was already redirected to the ConfirmedLesson screen, so I just added the cancellation button to this screen

From the tutor side:
- "Waiting for your confirmation" section => these lessons are not concerned by the cancellation (the tutor can simply choose to not teach this lesson), I did not change anything
- "Waiting for the Student Confirmation" section => same idea that the section Waiting for the Tutor Confirmation, it is now redirected to the ConfirmedLesson screen
- "Upcoming lessons" section => again like for student, I just added the cancellation button


#### Tests Added
- ConfirmedLessonTest.kt => tests that the cancellation button is displayed correctly, that the alert dialog is open when it needs to be, that the cancellation action is well done when we confirm the dialog, and add test for the other use of the screen (with other status than a confirmed lesson, cf Technical Details section)
- LessonViewModelTest.kt => tests that the lessons are correctly filtered and stored in the cancelledLesson state flow
- OverviewTest.kt => tests that the dialog to inform the user that a lesson have been cancelled is correctly displayed and can be aknowledge
- TutorMatchingtest.kt => tests that the cancellation button is displayed correctly, that the alert dialog is open when it need to be and that we can cancell a lesson properly


### Screenshot of the Modified Screens 
**Tutor cancellation**
From left to right:
- Cancellation from confirmed lesson => send an alert to student
- Cancellation from Waiting for student confirmation => remove to list
![image](https://github.com/user-attachments/assets/9e01be24-b0b2-4189-a08d-d4b632045954) ![image](https://github.com/user-attachments/assets/b115b5de-9eff-4f26-8fe7-44f2e57f5245)

**Student cancellation**
From left to right:
- Cancellation from confirmed lesson => send an alert to tutor 
- Cancellation from Waiting for the tutor confirmation => delete directly
- Cancellation from Waiting for your confirmation => delete directly

![image](https://github.com/user-attachments/assets/15efb531-7582-413d-a73f-2e66b897ed7e) ![image](https://github.com/user-attachments/assets/959768e1-233e-427f-aa9c-1259af0ac320) ![image](https://github.com/user-attachments/assets/91eee143-9b24-4159-9c43-462fd9706cd7)